### PR TITLE
Add xAuthMode param to getOAuthRequestToken to support reverse auth

### DIFF
--- a/twitter4j-async/src/main/java/twitter4j/AsyncTwitterImpl.java
+++ b/twitter4j-async/src/main/java/twitter4j/AsyncTwitterImpl.java
@@ -2602,6 +2602,22 @@ class AsyncTwitterImpl extends TwitterBaseImpl implements AsyncTwitter {
     }
 
     @Override
+    public void getOAuthRequestTokenAsync(final String callbackURL, final String xAuthAccessType, final String xAuthMode) {
+        getDispatcher().invokeLater(new AsyncTask(OAUTH_REQUEST_TOKEN, listeners) {
+            @Override
+            public void invoke(List<TwitterListener> listeners) throws TwitterException {
+                RequestToken token = twitter.getOAuthRequestToken(callbackURL, xAuthAccessType, xAuthMode);
+                for (TwitterListener listener : listeners) {
+                    try {
+                        listener.gotOAuthRequestToken(token);
+                    } catch (Exception ignore) {
+                    }
+                }
+            }
+        });
+    }
+
+    @Override
     public void getOAuthAccessTokenAsync() {
         getDispatcher().invokeLater(new AsyncTask(OAUTH_ACCESS_TOKEN, listeners) {
             @Override

--- a/twitter4j-async/src/main/java/twitter4j/auth/AsyncOAuthSupport.java
+++ b/twitter4j-async/src/main/java/twitter4j/auth/AsyncOAuthSupport.java
@@ -54,6 +54,21 @@ public interface AsyncOAuthSupport {
      */
     void getOAuthRequestTokenAsync(String callbackURL, String xAuthAccessType);
 
+
+    /**
+     * Retrieves a request token
+     *
+     * @param callbackURL     callback URL
+     * @param xAuthAccessType Overrides the access level an application requests to a users account. Supported values are read or write. This parameter is intended to allow a developer to register a read/write application but also request read only access when appropriate.
+     * @param xAuthMode       Set to reverse_auth to obtain a special request token to be used in the reverse auth process.
+     * @see <a href="https://dev.twitter.com/docs/auth/oauth/faq">OAuth FAQ | Twitter Developers</a>
+     * @see <a href="http://oauth.net/core/1.0a/#auth_step1">OAuth Core 1.0a - 6.1.  Obtaining an Unauthorized Request Token</a>
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/post/oauth/request_token">POST oauth/request_token | Twitter Developers</a>
+     * @since Twitter4J 3.0.0
+     */
+    void getOAuthRequestTokenAsync(String callbackURL, String xAuthAccessType, String xAuthMode);
+
+
     /**
      * Returns an access token associated with this instance.<br>
      * If no access token is associated with this instance, this will retrieve a new access token.

--- a/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
@@ -268,6 +268,11 @@ abstract class TwitterBaseImpl implements TwitterBase, java.io.Serializable, OAu
         return getOAuth().getOAuthRequestToken(callbackUrl, xAuthAccessType);
     }
 
+    @Override
+    public RequestToken getOAuthRequestToken(String callbackUrl, String xAuthAccessType, String xAuthMode) throws TwitterException {
+        return getOAuth().getOAuthRequestToken(callbackUrl, xAuthAccessType, xAuthMode);
+    }
+
     /**
      * {@inheritDoc}
      * Basic authenticated instance of this class will try acquiring an AccessToken using xAuth.<br>

--- a/twitter4j-core/src/main/java/twitter4j/auth/OAuthAuthorization.java
+++ b/twitter4j-core/src/main/java/twitter4j/auth/OAuthAuthorization.java
@@ -84,16 +84,21 @@ public class OAuthAuthorization implements Authorization, java.io.Serializable, 
 
     @Override
     public RequestToken getOAuthRequestToken() throws TwitterException {
-        return getOAuthRequestToken(null, null);
+        return getOAuthRequestToken(null, null, null);
     }
 
     @Override
     public RequestToken getOAuthRequestToken(String callbackURL) throws TwitterException {
-        return getOAuthRequestToken(callbackURL, null);
+        return getOAuthRequestToken(callbackURL, null, null);
     }
 
     @Override
     public RequestToken getOAuthRequestToken(String callbackURL, String xAuthAccessType) throws TwitterException {
+        return getOAuthRequestToken(callbackURL, xAuthAccessType, null);
+    }
+
+    @Override
+    public RequestToken getOAuthRequestToken(String callbackURL, String xAuthAccessType, String xAuthMode) throws TwitterException {
         if (oauthToken instanceof AccessToken) {
             throw new IllegalStateException("Access token already available.");
         }
@@ -103,6 +108,9 @@ public class OAuthAuthorization implements Authorization, java.io.Serializable, 
         }
         if (xAuthAccessType != null) {
             params.add(new HttpParameter("x_auth_access_type", xAuthAccessType));
+        }
+        if (xAuthMode != null) {
+            params.add(new HttpParameter("x_auth_mode", xAuthMode));
         }
         oauthToken = new RequestToken(http.post(conf.getOAuthRequestTokenURL(), params.toArray(new HttpParameter[params.size()]), this, null), this);
         return (RequestToken) oauthToken;

--- a/twitter4j-core/src/main/java/twitter4j/auth/OAuthSupport.java
+++ b/twitter4j-core/src/main/java/twitter4j/auth/OAuthSupport.java
@@ -75,6 +75,22 @@ public interface OAuthSupport {
     RequestToken getOAuthRequestToken(String callbackURL, String xAuthAccessType) throws TwitterException;
 
     /**
+     * Retrieves a request token
+     *
+     * @param callbackURL     callback URL
+     * @param xAuthAccessType Overrides the access level an application requests to a users account. Supported values are read or write. This parameter is intended to allow a developer to register a read/write application but also request read only access when appropriate.
+     * @param xAuthMode       Set to reverse_auth to obtain a special request token to be used in the reverse auth process.
+     * @return generated request token
+     * @throws TwitterException      when Twitter service or network is unavailable
+     * @throws IllegalStateException access token is already available
+     * @see <a href="https://dev.twitter.com/docs/auth/oauth/faq">OAuth FAQ | Twitter Developers</a>
+     * @see <a href="http://oauth.net/core/1.0a/#auth_step1">OAuth Core 1.0a - 6.1.  Obtaining an Unauthorized Request Token</a>
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/post/oauth/request_token">POST oauth/request_token | Twitter Developers</a>
+     * @since Twitter4J 2.2.3
+     */
+    RequestToken getOAuthRequestToken(String callbackURL, String xAuthAccessType, String xAuthMode) throws TwitterException;
+
+    /**
      * Returns an access token associated with this instance.<br>
      * If no access token is associated with this instance, this will retrieve a new access token.
      *


### PR DESCRIPTION
The reverse auth process needs a special request token, see https://dev.twitter.com/docs/ios/using-reverse-auth#step-1-obtain-a-special-request-token

To get a special request token a new `x_auth_mode` parameter is used for the request to `https://api.twitter.com/oauth/request_token`.

Example usage:

```java
Twitter twitter = new TwitterFactory().getInstance();
twitter.setOAuthConsumer(consumerKey, consumerSecret);
RequestToken rt = twitter.getOAuthRequestToken(null, null, "reverse_auth");
```

You can make the request to `/oauth/request_token` server side and then send `rt` to your client to get an access token to share with your server.

See also discussion at https://groups.google.com/d/msg/twitter4j/7Gtb798nI-k/XjO4S9q7O-8J