### PR TITLE
Status search parameter parsing

### DIFF
--- a/twitter4j-core/src/internal-http/java/twitter4j/HttpParameter.java
+++ b/twitter4j-core/src/internal-http/java/twitter4j/HttpParameter.java
@@ -19,7 +19,9 @@ package twitter4j;
 import java.io.File;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -277,5 +279,46 @@ public final class HttpParameter implements Comparable<HttpParameter>, java.io.S
             }
         }
         return buf.toString();
+    }
+
+    /**
+     * @param value string to be decoded. The natural opposite of encode() above.
+     * @return encoded string
+     * @see <a href="http://wiki.oauth.net/TestCases">OAuth / TestCases</a>
+     * @see <a href="http://groups.google.com/group/oauth/browse_thread/thread/a8398d0521f4ae3d/9d79b698ab217df2?hl=en&lnk=gst&q=space+encoding#9d79b698ab217df2">Space encoding - OAuth | Google Groups</a>
+     * @see <a href="http://tools.ietf.org/html/rfc3986#section-2.1">RFC 3986 - Uniform Resource Identifier (URI): Generic Syntax - 2.1. Percent-Encoding</a>
+     */
+    public static String decode(String value) {
+        value = value.replace("%2A", "*");
+        value = value.replace("%2a", "*");
+        value = value.replace("%20", " ");
+        
+        String decoded=null;
+        try {
+            decoded = URLDecoder.decode(value, "UTF-8");
+        }
+        catch(UnsupportedEncodingException ignore) {
+        }
+        
+        return decoded;
+    }
+
+    /**
+     * Parses a query string without the leading "?"
+     * 
+     * @param queryParameters a query parameter string, like a=hello&b=world
+     */
+    public static List<HttpParameter> decodeParameters(String queryParameters) {
+        List<HttpParameter> result=new ArrayList<HttpParameter>();
+        for (String pair : queryParameters.split("&")) {
+            String[] parts=pair.split("=", 2);
+            if(parts.length == 2) {
+                String name=decode(parts[0]);
+                String value=decode(parts[1]);
+                if(!name.equals("") && !value.equals(""))
+                    result.add(new HttpParameter(name, value));
+            }
+        }
+        return result;
     }
 }

--- a/twitter4j-core/src/main/java/twitter4j/Query.java
+++ b/twitter4j-core/src/main/java/twitter4j/Query.java
@@ -17,7 +17,9 @@
 package twitter4j;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A data class represents search query.<br>
@@ -48,10 +50,58 @@ public final class Query implements java.io.Serializable {
     public Query(String query) {
         this.query = query;
     }
-
-    static Query createWithNextPageQuery(String nextPageQuery) {
+    
+    /* package */ static Query createWithNextPageQuery(String nextPageQuery) {
         Query query = new Query();
         query.nextPageQuery = nextPageQuery;
+        
+        if(nextPageQuery != null) {
+            String nextPageParameters=nextPageQuery.substring(1, nextPageQuery.length());
+            
+            Map<String,String> params=new LinkedHashMap<String,String>();
+            for(HttpParameter param : HttpParameter.decodeParameters(nextPageParameters)) {
+                // Yes, we'll overwrite duplicate parameters, but we should not
+                // get duplicate parameters from this endpoint.
+                params.put(param.getName(), param.getValue());
+            }
+            
+            if(params.containsKey("q"))
+                query.setQuery(params.get("q"));
+            if(params.containsKey("lang"))
+                query.setLang(params.get("lang"));
+            if(params.containsKey("locale"))
+                query.setLocale(params.get("locale"));
+            if(params.containsKey("max_id"))
+                query.setMaxId(Long.parseLong(params.get("max_id")));
+            if(params.containsKey("count"))
+                query.setCount(Integer.parseInt(params.get("count")));
+            if(params.containsKey("since_id"))
+                query.setSinceId(Long.parseLong(params.get("since_id")));
+            if(params.containsKey("geocode")) {
+                String[] parts=params.get("geocode").split(",");
+                double latitude=Double.parseDouble(parts[0]);
+                double longitude=Double.parseDouble(parts[1]);
+                
+                double radius=0.0;
+                Query.Unit unit=null;
+                String radiusstr=parts[2];
+                for(Query.Unit value : Query.Unit.values())
+                    if(radiusstr.endsWith(value.name())) {
+                        radius = Double.parseDouble(radiusstr.substring(0, radiusstr.length()-2));
+                        unit   = value;
+                        break;
+                    }
+                if(unit == null)
+                    throw new IllegalArgumentException("unrecognized geocode radius: "+radiusstr);
+                
+                query.setGeoCode(new GeoLocation(latitude, longitude), radius, unit);
+            }
+            if(params.containsKey("result_type"))
+                query.setResultType(Query.ResultType.valueOf(params.get("result_type")));
+            
+            // We don't pull out since, until -- they get pushed into the query
+        }
+        
         return query;
     }
 

--- a/twitter4j-core/src/main/java/twitter4j/Query.java
+++ b/twitter4j-core/src/main/java/twitter4j/Query.java
@@ -75,8 +75,6 @@ public final class Query implements java.io.Serializable {
                 query.setMaxId(Long.parseLong(params.get("max_id")));
             if(params.containsKey("count"))
                 query.setCount(Integer.parseInt(params.get("count")));
-            if(params.containsKey("since_id"))
-                query.setSinceId(Long.parseLong(params.get("since_id")));
             if(params.containsKey("geocode")) {
                 String[] parts=params.get("geocode").split(",");
                 double latitude=Double.parseDouble(parts[0]);


### PR DESCRIPTION
First, thanks for building and maintaining twitter4j for so long. It's a pleasure to use! :)

My team recently tried to do some simple status searching, and we noticed that while paging status searches is easy, the "next page" fields are not exposed by the current API. (They're handled opaquely by the `Query` object using a anextPagea query parameters variable.)

This change parses those `nextPage` variables and extracts the values from that parameter string into the greater `Query` object whenever possible, namely:

* `query`
* `lang`
* `locale`
* `max_id`
* `count`
* `geocode`
* `result_type`

Other variables -- `since`, `until`, and `since_id` -- get rolled into the query (e.g., `since:2014-1-1`) and so are not parsed into the `Query`.

This change is fully backwards compatible. This change would make more information available to those who wish to use it. I've also added a test for the change.

Hopefully all this makes sense! Let me know if you have any questions for me. :)
