### PR TITLE
Some useful changes to monitorize streams

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
@@ -138,7 +138,7 @@ abstract class TwitterBaseImpl implements TwitterBase, java.io.Serializable, OAu
     }
 
     @Override
-    public void onRateLimitStatus(Consumer<RateLimitStatusEvent> action) {
+    public void onRateLimitStatus(final Consumer<RateLimitStatusEvent> action) {
         rateLimitStatusListeners.add(new RateLimitStatusListener() {
             @Override
             public void onRateLimitStatus(RateLimitStatusEvent event) {
@@ -152,7 +152,7 @@ abstract class TwitterBaseImpl implements TwitterBase, java.io.Serializable, OAu
     }
 
     @Override
-    public void onRateLimitReached(Consumer<RateLimitStatusEvent> action) {
+    public void onRateLimitReached(final Consumer<RateLimitStatusEvent> action) {
         rateLimitStatusListeners.add(new RateLimitStatusListener() {
             @Override
             public void onRateLimitStatus(RateLimitStatusEvent event) {

--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStream.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStream.java
@@ -15,6 +15,7 @@
  */
 package twitter4j;
 
+import twitter4j.TwitterStreamImpl.TwitterStreamConsumer;
 import twitter4j.auth.OAuthSupport;
 import twitter4j.util.function.Consumer;
 
@@ -174,4 +175,11 @@ public interface TwitterStream extends OAuthSupport, TwitterBase {
      * @since Twitter4J 2.1.9
      */
     void shutdown();
+    
+    /**
+     * Set the stream name
+     * 
+     * @param streamName
+     */
+    public void setStreamName(String streamName);
 }

--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
@@ -415,7 +415,7 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
     }
 
     @Override
-    public synchronized TwitterStream onStatus(Consumer<Status> action) {
+    public synchronized TwitterStream onStatus(final Consumer<Status> action) {
         streamListeners.add(new StatusAdapter() {
             @Override
             public void onStatus(Status status) {
@@ -427,7 +427,7 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
     }
 
     @Override
-    public synchronized TwitterStream onException(Consumer<Exception> action) {
+    public synchronized TwitterStream onException(final Consumer<Exception> action) {
         streamListeners.add(new StatusAdapter() {
             @Override
             public void onException(Exception ex) {

--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
@@ -44,6 +44,8 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
 
     private final String stallWarningsGetParam;
     private final HttpParameter stallWarningsParam;
+    
+    private String streamName = "";
 
     /*package*/
     TwitterStreamImpl(Configuration conf, Authorization auth) {
@@ -56,6 +58,10 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
 
         stallWarningsGetParam = "stall_warnings=" + (conf.isStallWarningsEnabled() ? "true" : "false");
         stallWarningsParam = new HttpParameter("stall_warnings", conf.isStallWarningsEnabled());
+    }
+    
+    public void setStreamName(String streamName){
+    	this.streamName = streamName;
     }
 
     /* Streaming API */
@@ -556,8 +562,8 @@ class TwitterStreamImpl extends TwitterBaseImpl implements TwitterStream {
                         }
                         // connection established successfully
                         timeToSleep = NO_WAIT;
-                        logger.info("Receiving status stream.");
-                        setStatus("[Receiving stream]");
+                        logger.info("Receiving status stream."+streamName);
+                        setStatus("[Receiving stream]"+streamName);
                         while (!closed) {
                             try {
                                 stream.next(this.streamListeners, this.rawStreamListeners);


### PR DESCRIPTION
Hi,

We are using twitter4j for an Sparsity-Technologies application. We have considered useful to monitorize which are the active streamings assigning a name to the related thread because we have a thread per user. 

We have attached also a minor change to work with Java 6. We would be grateful if you add our changes into the future deployed version. 

Thank you in advance