### PR TITLE
TFJ-870, TFJ-871 Support for extra lists resources parameters

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,7 @@ Hiroaki Takeuchi <takke30 at gmail.com> @takke
 Hiroki Takemoto <pompopo at gmail.com> @pompopo
 Hiroshi Sugimori <mamamadata at gmail.com> @ham1975
 Hitoshi Kunimatsu <hkhumanoid at gmail.com>
+Igor Brigadir <igor.brigadir at insight-centre.org> @igorbrigadir
 JJ Kelley <jjthemachine at gmail.com> @jjthemachine
 Jacob Elder <jacob.elder@gmail.com> @jelder
 Jacob S. Hoffman-Andrews <jsha at twitter.com> @j4cob

--- a/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
@@ -138,7 +138,7 @@ abstract class TwitterBaseImpl implements TwitterBase, java.io.Serializable, OAu
     }
 
     @Override
-    public void onRateLimitStatus(Consumer<RateLimitStatusEvent> action) {
+    public void onRateLimitStatus(final Consumer<RateLimitStatusEvent> action) {
         rateLimitStatusListeners.add(new RateLimitStatusListener() {
             @Override
             public void onRateLimitStatus(RateLimitStatusEvent event) {
@@ -152,7 +152,7 @@ abstract class TwitterBaseImpl implements TwitterBase, java.io.Serializable, OAu
     }
 
     @Override
-    public void onRateLimitReached(Consumer<RateLimitStatusEvent> action) {
+    public void onRateLimitReached(final Consumer<RateLimitStatusEvent> action) {
         rateLimitStatusListeners.add(new RateLimitStatusListener() {
             @Override
             public void onRateLimitStatus(RateLimitStatusEvent event) {

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -1012,7 +1012,19 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, int count, long cursor) throws TwitterException {
         return getUserListMemberships(listMemberScreenName, count, cursor, false);
     }
-
+    
+    @Override
+    public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, long cursor, boolean filterToOwnedLists) throws TwitterException {
+        return getUserListMemberships(listMemberScreenName, 20, cursor, filterToOwnedLists);
+    }
+    
+    @Override
+    public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, int count, long cursor, boolean filterToOwnedLists) throws TwitterException {
+        return factory.createPagableUserListList(get(conf.getRestBaseURL()
+                + "lists/memberships.json?screen_name=" + listMemberScreenName + "&count=" + count + "&cursor=" + cursor
+                + "&filter_to_owned_lists=" + filterToOwnedLists));
+    }
+    
     @Override
     public PagableResponseList<UserList> getUserListMemberships(long listMemberId, long cursor) throws TwitterException {
         return getUserListMemberships(listMemberId, cursor, false);
@@ -1036,34 +1048,51 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
-    public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, long cursor, boolean filterToOwnedLists) throws TwitterException {
-        return getUserListMemberships(listMemberScreenName, 20, cursor, filterToOwnedLists);
+    public PagableResponseList<User> getUserListSubscribers(long listId, long cursor) throws TwitterException {
+        return getUserListSubscribers(listId, 20, cursor, false);
     }
     
     @Override
-    public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, int count, long cursor, boolean filterToOwnedLists) throws TwitterException {
-        return factory.createPagableUserListList(get(conf.getRestBaseURL()
-                + "lists/memberships.json?screen_name=" + listMemberScreenName + "&count=" + count + "&cursor=" + cursor
-                + "&filter_to_owned_lists=" + filterToOwnedLists));
+    public PagableResponseList<User> getUserListSubscribers(long listId, int count, long cursor) throws TwitterException {
+        return getUserListSubscribers(listId, count, cursor, false);
     }
-
+    
     @Override
-    public PagableResponseList<User> getUserListSubscribers(long listId, long cursor) throws TwitterException {
-        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json?list_id=" + listId + "&cursor=" + cursor));
+    public PagableResponseList<User> getUserListSubscribers(long listId, int count, long cursor, boolean skip_status) throws TwitterException {
+        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json?list_id=" + listId 
+            + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skip_status));
     }
 
     @Override
     public PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, long cursor) throws TwitterException {
+        return getUserListSubscribers(ownerId, slug, 20, cursor, false);
+    }
+    
+    @Override
+    public PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, int count, long cursor) throws TwitterException {
+        return getUserListSubscribers(ownerId, slug, count, cursor, false);
+    }
+    
+    @Override
+    public PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, int count, long cursor, boolean skip_status) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json?owner_id=" + ownerId
-                + "&slug=" + slug + "&cursor=" + cursor));
+                + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skip_status));
     }
 
     @Override
-    public PagableResponseList<User> getUserListSubscribers(
-            String ownerScreenName, String slug, long cursor)
-            throws TwitterException {
+    public PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, long cursor) throws TwitterException {
+        return getUserListSubscribers(ownerScreenName, slug, 20, cursor, false);
+    }
+    
+    @Override
+    public PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, int count, long cursor) throws TwitterException {
+        return getUserListSubscribers(ownerScreenName, slug, count, cursor, false);
+    }
+    
+    @Override
+    public PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, int count, long cursor, boolean skip_status) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json?owner_screen_name=" + ownerScreenName
-                + "&slug=" + slug + "&cursor=" + cursor));
+                + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skip_status));
     }
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -995,31 +995,55 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
 
     @Override
     public PagableResponseList<UserList> getUserListMemberships(long cursor) throws TwitterException {
-        return factory.createPagableUserListList(get(conf.getRestBaseURL() + "lists/memberships.json?cursor=" + cursor));
-
+        return getUserListMemberships(20, cursor);
+    }
+    
+    @Override
+    public PagableResponseList<UserList> getUserListMemberships(int count, long cursor) throws TwitterException {
+        return factory.createPagableUserListList(get(conf.getRestBaseURL() + "lists/memberships.json?cursor=" + cursor + "&count=" + count));
     }
 
     @Override
     public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, long cursor) throws TwitterException {
         return getUserListMemberships(listMemberScreenName, cursor, false);
     }
+    
+    @Override
+    public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, int count, long cursor) throws TwitterException {
+        return getUserListMemberships(listMemberScreenName, count, cursor, false);
+    }
 
     @Override
     public PagableResponseList<UserList> getUserListMemberships(long listMemberId, long cursor) throws TwitterException {
         return getUserListMemberships(listMemberId, cursor, false);
     }
+    
+    @Override
+    public PagableResponseList<UserList> getUserListMemberships(long listMemberId, int count, long cursor) throws TwitterException {
+        return getUserListMemberships(listMemberId, count, cursor, false);
+    }
 
     @Override
     public PagableResponseList<UserList> getUserListMemberships(long listMemberId, long cursor, boolean filterToOwnedLists) throws TwitterException {
+        return getUserListMemberships(listMemberId, 20, cursor, filterToOwnedLists);
+    }
+    
+    @Override
+    public PagableResponseList<UserList> getUserListMemberships(long listMemberId, int count, long cursor, boolean filterToOwnedLists) throws TwitterException {
         return factory.createPagableUserListList(get(conf.getRestBaseURL()
-                + "lists/memberships.json?user_id=" + listMemberId + "&cursor=" + cursor + "&filter_to_owned_lists="
+                + "lists/memberships.json?user_id=" + listMemberId + "&count=" + count + "&cursor=" + cursor + "&filter_to_owned_lists="
                 + filterToOwnedLists));
     }
 
     @Override
     public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, long cursor, boolean filterToOwnedLists) throws TwitterException {
+        return getUserListMemberships(listMemberScreenName, 20, cursor, filterToOwnedLists);
+    }
+    
+    @Override
+    public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, int count, long cursor, boolean filterToOwnedLists) throws TwitterException {
         return factory.createPagableUserListList(get(conf.getRestBaseURL()
-                + "lists/memberships.json?screen_name=" + listMemberScreenName + "&cursor=" + cursor
+                + "lists/memberships.json?screen_name=" + listMemberScreenName + "&count=" + count + "&cursor=" + cursor
                 + "&filter_to_owned_lists=" + filterToOwnedLists));
     }
 

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -1108,7 +1108,6 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
                 , new HttpParameter("slug", slug)}));
     }
 
-
     @Override
     public UserList createUserListSubscription(String ownerScreenName,
                                                String slug) throws TwitterException {
@@ -1229,23 +1228,52 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
-    public PagableResponseList<User> getUserListMembers(long listId
-            , long cursor) throws TwitterException {
-        return factory.createPagableUserList(get(conf.getRestBaseURL() +
-                "lists/members.json?list_id=" + listId + "&cursor=" + cursor));
+    public PagableResponseList<User> getUserListMembers(long listId, long cursor) throws TwitterException {
+        return getUserListMembers(listId, 20, cursor, false);
     }
-
+    
+    @Override
+    public PagableResponseList<User> getUserListMembers(long listId, int count, long cursor) throws TwitterException {
+        return getUserListMembers(listId, count, cursor, false);
+    }
+    
+    @Override
+    public PagableResponseList<User> getUserListMembers(long listId, int count, long cursor, boolean skip_status) throws TwitterException {
+        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/members.json?list_id=" + listId
+            + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skip_status));
+    }
+    
     @Override
     public PagableResponseList<User> getUserListMembers(long ownerId, String slug, long cursor) throws TwitterException {
-        return factory.createPagableUserList(get(conf.getRestBaseURL() +
-                "lists/members.json?owner_id=" + ownerId + "&slug=" + slug + "&cursor=" + cursor));
+        return getUserListMembers(ownerId, slug, 20, cursor, false);
+    }
+    
+    @Override
+    public PagableResponseList<User> getUserListMembers(long ownerId, String slug, int count, long cursor) throws TwitterException {
+        return getUserListMembers(ownerId, slug, count, cursor, false);
     }
 
     @Override
-    public PagableResponseList<User> getUserListMembers(String ownerScreenName,
-                                                        String slug, long cursor) throws TwitterException {
+    public PagableResponseList<User> getUserListMembers(long ownerId, String slug, int count, long cursor, boolean skip_status) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() +
-                "lists/members.json?owner_screen_name=" + ownerScreenName + "&slug=" + slug + "&cursor=" + cursor));
+                "lists/members.json?owner_id=" + ownerId + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skip_status));
+    }
+    
+    @Override
+    public PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, long cursor) throws TwitterException {
+      return getUserListMembers(ownerScreenName, slug, 20, cursor, false);
+    }
+    
+    @Override
+    public PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, int count, long cursor) throws TwitterException {
+      return getUserListMembers(ownerScreenName, slug, count, cursor, false);
+    }
+
+    @Override
+    public PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, int count, long cursor, boolean skip_status) throws TwitterException {
+        return factory.createPagableUserList(get(conf.getRestBaseURL() +
+                "lists/members.json?owner_screen_name=" + ownerScreenName + "&slug=" + slug
+                + "&count="+ count + "&cursor=" + cursor + "&skip_status=" + skip_status));
     }
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -1388,6 +1388,10 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
         return factory.createPagableUserListList(get(conf.getRestBaseURL() + "lists/subscriptions.json?screen_name="
                 + listOwnerScreenName + "&cursor=" + cursor));
     }
+    
+    public PagableResponseList<UserList> getUserListsOwnerships(String listOwnerScreenName, long cursor) throws TwitterException {
+      return getUserListsOwnerships(listOwnerScreenName, 20, cursor);
+    }
 
     @Override
     public PagableResponseList<UserList> getUserListsOwnerships(String listOwnerScreenName, int count, long cursor) throws TwitterException {
@@ -1397,6 +1401,11 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
                         , new HttpParameter("cursor", cursor)
                 }
         ));
+    }
+    
+    @Override
+    public PagableResponseList<UserList> getUserListsOwnerships(long listOwnerId, long cursor) throws TwitterException {
+      return getUserListsOwnerships(listOwnerId, 20, cursor);
     }
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -901,10 +901,20 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     public ResponseList<UserList> getUserLists(String listOwnerScreenName) throws TwitterException {
         return factory.createUserListList(get(conf.getRestBaseURL() + "lists/list.json?screen_name=" + listOwnerScreenName));
     }
+    
+    @Override
+    public ResponseList<UserList> getUserLists(String listOwnerScreenName, boolean reverse) throws TwitterException {
+        return factory.createUserListList(get(conf.getRestBaseURL() + "lists/list.json?screen_name=" + listOwnerScreenName + "&reverse=" + reverse));
+    }
 
     @Override
     public ResponseList<UserList> getUserLists(long listOwnerUserId) throws TwitterException {
         return factory.createUserListList(get(conf.getRestBaseURL() + "lists/list.json?user_id=" + listOwnerUserId));
+    }
+    
+    @Override
+    public ResponseList<UserList> getUserLists(long listOwnerUserId, boolean reverse) throws TwitterException {
+        return factory.createUserListList(get(conf.getRestBaseURL() + "lists/list.json?user_id=" + listOwnerUserId + "&reverse=" + reverse));
     }
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -1058,9 +1058,9 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
     
     @Override
-    public PagableResponseList<User> getUserListSubscribers(long listId, int count, long cursor, boolean skip_status) throws TwitterException {
+    public PagableResponseList<User> getUserListSubscribers(long listId, int count, long cursor, boolean skipStatus) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json?list_id=" + listId 
-            + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skip_status));
+            + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
     }
 
     @Override
@@ -1074,9 +1074,9 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
     
     @Override
-    public PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, int count, long cursor, boolean skip_status) throws TwitterException {
+    public PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, int count, long cursor, boolean skipStatus) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json?owner_id=" + ownerId
-                + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skip_status));
+                + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
     }
 
     @Override
@@ -1090,9 +1090,9 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
     
     @Override
-    public PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, int count, long cursor, boolean skip_status) throws TwitterException {
+    public PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, int count, long cursor, boolean skipStatus) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json?owner_screen_name=" + ownerScreenName
-                + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skip_status));
+                + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
     }
 
     @Override
@@ -1238,9 +1238,9 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
     
     @Override
-    public PagableResponseList<User> getUserListMembers(long listId, int count, long cursor, boolean skip_status) throws TwitterException {
+    public PagableResponseList<User> getUserListMembers(long listId, int count, long cursor, boolean skipStatus) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/members.json?list_id=" + listId
-            + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skip_status));
+            + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
     }
     
     @Override
@@ -1254,9 +1254,9 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
-    public PagableResponseList<User> getUserListMembers(long ownerId, String slug, int count, long cursor, boolean skip_status) throws TwitterException {
+    public PagableResponseList<User> getUserListMembers(long ownerId, String slug, int count, long cursor, boolean skipStatus) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() +
-                "lists/members.json?owner_id=" + ownerId + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skip_status));
+                "lists/members.json?owner_id=" + ownerId + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
     }
     
     @Override
@@ -1270,10 +1270,10 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
-    public PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, int count, long cursor, boolean skip_status) throws TwitterException {
+    public PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, int count, long cursor, boolean skipStatus) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() +
                 "lists/members.json?owner_screen_name=" + ownerScreenName + "&slug=" + slug
-                + "&count="+ count + "&cursor=" + cursor + "&skip_status=" + skip_status));
+                + "&count="+ count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
     }
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -1000,7 +1000,10 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     
     @Override
     public PagableResponseList<UserList> getUserListMemberships(int count, long cursor) throws TwitterException {
-        return factory.createPagableUserListList(get(conf.getRestBaseURL() + "lists/memberships.json?cursor=" + cursor + "&count=" + count));
+        return factory.createPagableUserListList(get(conf.getRestBaseURL() + "lists/memberships.json", new HttpParameter[]{
+          new HttpParameter("cursor", cursor), 
+          new HttpParameter("count", count)
+      }));
     }
 
     @Override
@@ -1021,8 +1024,12 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     @Override
     public PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, int count, long cursor, boolean filterToOwnedLists) throws TwitterException {
         return factory.createPagableUserListList(get(conf.getRestBaseURL()
-                + "lists/memberships.json?screen_name=" + listMemberScreenName + "&count=" + count + "&cursor=" + cursor
-                + "&filter_to_owned_lists=" + filterToOwnedLists));
+                + "lists/memberships.json", new HttpParameter[]{
+          new HttpParameter("screen_name", listMemberScreenName), 
+          new HttpParameter("count", count),
+          new HttpParameter("cursor", cursor),
+          new HttpParameter("filter_to_owned_lists", filterToOwnedLists),
+      }));
     }
     
     @Override
@@ -1042,9 +1049,12 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     
     @Override
     public PagableResponseList<UserList> getUserListMemberships(long listMemberId, int count, long cursor, boolean filterToOwnedLists) throws TwitterException {
-        return factory.createPagableUserListList(get(conf.getRestBaseURL()
-                + "lists/memberships.json?user_id=" + listMemberId + "&count=" + count + "&cursor=" + cursor + "&filter_to_owned_lists="
-                + filterToOwnedLists));
+        return factory.createPagableUserListList(get(conf.getRestBaseURL() + "lists/memberships.json", new HttpParameter[]{
+          new HttpParameter("user_id", listMemberId), 
+          new HttpParameter("count", count),
+          new HttpParameter("cursor", cursor),
+          new HttpParameter("filter_to_owned_lists", filterToOwnedLists)
+      }));
     }
 
     @Override
@@ -1059,8 +1069,12 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     
     @Override
     public PagableResponseList<User> getUserListSubscribers(long listId, int count, long cursor, boolean skipStatus) throws TwitterException {
-        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json?list_id=" + listId 
-            + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
+        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json", new HttpParameter[]{
+          new HttpParameter("list_id", listId), 
+          new HttpParameter("count", count),
+          new HttpParameter("cursor", cursor),
+          new HttpParameter("skip_status", skipStatus)
+          }));
     }
 
     @Override
@@ -1075,8 +1089,13 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     
     @Override
     public PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, int count, long cursor, boolean skipStatus) throws TwitterException {
-        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json?owner_id=" + ownerId
-                + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
+        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json", new HttpParameter[]{
+          new HttpParameter("owner_id", ownerId), 
+          new HttpParameter("slug", slug),
+          new HttpParameter("count", count),
+          new HttpParameter("cursor", cursor),
+          new HttpParameter("skip_status", skipStatus)
+          }));
     }
 
     @Override
@@ -1091,8 +1110,13 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     
     @Override
     public PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, int count, long cursor, boolean skipStatus) throws TwitterException {
-        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json?owner_screen_name=" + ownerScreenName
-                + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
+        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/subscribers.json", new HttpParameter[]{
+          new HttpParameter("owner_screen_name", ownerScreenName), 
+          new HttpParameter("slug", slug),
+          new HttpParameter("count", count),
+          new HttpParameter("cursor", cursor),
+          new HttpParameter("skip_status", skipStatus)
+      }));
     }
 
     @Override
@@ -1221,8 +1245,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
-    public User showUserListMembership(String ownerScreenName, String slug,
-                                       long userId) throws TwitterException {
+    public User showUserListMembership(String ownerScreenName, String slug, long userId) throws TwitterException {
         return factory.createUser(get(conf.getRestBaseURL() +
                 "lists/members/show.json?owner_screen_name=" + ownerScreenName + "&slug=" + slug + "&user_id=" + userId));
     }
@@ -1239,8 +1262,12 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     
     @Override
     public PagableResponseList<User> getUserListMembers(long listId, int count, long cursor, boolean skipStatus) throws TwitterException {
-        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/members.json?list_id=" + listId
-            + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
+        return factory.createPagableUserList(get(conf.getRestBaseURL() + "lists/members.json", new HttpParameter[]{
+          new HttpParameter("list_id", listId), 
+          new HttpParameter("count", count),
+          new HttpParameter("cursor", cursor),
+          new HttpParameter("skip_status", skipStatus),
+      }));
     }
     
     @Override
@@ -1256,7 +1283,13 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     @Override
     public PagableResponseList<User> getUserListMembers(long ownerId, String slug, int count, long cursor, boolean skipStatus) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() +
-                "lists/members.json?owner_id=" + ownerId + "&slug=" + slug + "&count=" + count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
+                "lists/members.json", new HttpParameter[]{
+          new HttpParameter("owner_id", ownerId), 
+          new HttpParameter("slug", slug),
+          new HttpParameter("count", count),
+          new HttpParameter("cursor", cursor),
+          new HttpParameter("skip_status", skipStatus),
+      }));
     }
     
     @Override
@@ -1272,8 +1305,13 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     @Override
     public PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, int count, long cursor, boolean skipStatus) throws TwitterException {
         return factory.createPagableUserList(get(conf.getRestBaseURL() +
-                "lists/members.json?owner_screen_name=" + ownerScreenName + "&slug=" + slug
-                + "&count="+ count + "&cursor=" + cursor + "&skip_status=" + skipStatus));
+                "lists/members.json", new HttpParameter[]{
+          new HttpParameter("owner_screen_name", ownerScreenName), 
+          new HttpParameter("slug", slug),
+          new HttpParameter("count", count),
+          new HttpParameter("cursor", cursor),
+          new HttpParameter("skip_status", skipStatus),
+      }));
     }
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -1422,9 +1422,33 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
-    public PagableResponseList<UserList> getUserListSubscriptions(String listOwnerScreenName, long cursor) throws TwitterException {
-        return factory.createPagableUserListList(get(conf.getRestBaseURL() + "lists/subscriptions.json?screen_name="
-                + listOwnerScreenName + "&cursor=" + cursor));
+    public PagableResponseList<UserList> getUserListSubscriptions(String listSubscriberScreenName, long cursor) throws TwitterException {
+        return getUserListSubscriptions(listSubscriberScreenName, 20, cursor);
+    }
+    
+    @Override
+    public PagableResponseList<UserList> getUserListSubscriptions(String listSubscriberScreenName, int count, long cursor) throws TwitterException {
+        return factory.createPagableUserListList(get(conf.getRestBaseURL() + "lists/subscriptions.json",
+                new HttpParameter[]{new HttpParameter("screen_name", listSubscriberScreenName)
+                        , new HttpParameter("count", count)
+                        , new HttpParameter("cursor", cursor)
+                }
+        ));
+    }
+    
+    @Override
+    public PagableResponseList<UserList> getUserListSubscriptions(long listSubscriberId, long cursor) throws TwitterException {
+        return getUserListSubscriptions(listSubscriberId, 20, cursor);
+    }
+    
+    @Override
+    public PagableResponseList<UserList> getUserListSubscriptions(long listSubscriberId, int count, long cursor) throws TwitterException {
+        return factory.createPagableUserListList(get(conf.getRestBaseURL() + "lists/subscriptions.json",
+                new HttpParameter[]{new HttpParameter("user_id", listSubscriberId)
+                        , new HttpParameter("count", count)
+                        , new HttpParameter("cursor", cursor)
+                }
+        ));
     }
     
     public PagableResponseList<UserList> getUserListsOwnerships(String listOwnerScreenName, long cursor) throws TwitterException {

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -899,7 +899,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
 
     @Override
     public ResponseList<UserList> getUserLists(String listOwnerScreenName) throws TwitterException {
-        return factory.createUserListList(get(conf.getRestBaseURL() + "lists/list.json?screen_name=" + listOwnerScreenName));
+        return getUserLists(listOwnerScreenName, false);
     }
     
     @Override
@@ -909,7 +909,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
 
     @Override
     public ResponseList<UserList> getUserLists(long listOwnerUserId) throws TwitterException {
-        return factory.createUserListList(get(conf.getRestBaseURL() + "lists/list.json?user_id=" + listOwnerUserId));
+        return getUserLists(listOwnerUserId, false);
     }
     
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
@@ -229,6 +229,21 @@ public interface ListsResources {
      */
     PagableResponseList<UserList> getUserListMemberships(long cursor)
             throws TwitterException;
+    
+    /**
+     * List the lists the authenticating user has been added to.
+     * <br>This method calls https://api.twitter.com/1.1/lists/memberships.json
+     *
+     * @param count The amount of results to return per page. No more than 1000 results will ever be returned in a single page.
+     * @param cursor Breaks the results into pages. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the list of lists
+     * @throws TwitterException      when Twitter service or network is unavailable
+     * @throws IllegalStateException when authorization is not enabled
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/memberships">GET lists/memberships | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<UserList> getUserListMemberships(int count, long cursor)
+            throws TwitterException;
 
     /**
      * List the lists the specified user has been added to.
@@ -243,6 +258,21 @@ public interface ListsResources {
      */
     PagableResponseList<UserList> getUserListMemberships(long listMemberId, long cursor)
             throws TwitterException;
+    
+    /**
+     * List the lists the specified user has been added to.
+     * <br>This method calls https://api.twitter.com/1.1/lists/memberships.json
+     *
+     * @param listMemberId The id of the list member
+     * @param count The amount of results to return per page. No more than 1000 results will ever be returned in a single page.
+     * @param cursor       Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the list of lists
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/memberships">GET lists/memberships | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<UserList> getUserListMemberships(long listMemberId, int count, long cursor)
+            throws TwitterException;
 
     /**
      * List the lists the specified user has been added to.
@@ -256,6 +286,21 @@ public interface ListsResources {
      * @since Twitter4J 2.1.0
      */
     PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, long cursor)
+            throws TwitterException;
+    
+    /**
+     * List the lists the specified user has been added to.
+     * <br>This method calls https://api.twitter.com/1.1/lists/memberships.json
+     *
+     * @param listMemberScreenName The screen name of the list member
+     * @param count The amount of results to return per page. No more than 1000 results will ever be returned in a single page.
+     * @param cursor               Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the list of lists
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/memberships">GET lists/memberships | Twitter Developers</a>
+     * @since Twitter4J 2.1.0
+     */
+    PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, int count, long cursor)
             throws TwitterException;
 
     /**
@@ -273,7 +318,24 @@ public interface ListsResources {
      */
     PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, long cursor, boolean filterToOwnedLists)
             throws TwitterException;
-
+    
+    /**
+     * List the lists the specified user has been added to.
+     * <br>This method calls https://api.twitter.com/1.1/lists/memberships.json
+     *
+     * @param listMemberScreenName The screen name of the list member
+     * @param count The amount of results to return per page. No more than 1000 results will ever be returned in a single page.
+     * @param cursor               Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @param filterToOwnedLists   Whether to return just lists the authenticating user owns, and the user represented by listMemberScreenName is a member of.
+     * @return the list of lists
+     * @throws TwitterException      when Twitter service or network is unavailable
+     * @throws IllegalStateException when filerToOwnedLists is true but authorization is not enabled
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/memberships">GET lists/memberships | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<UserList> getUserListMemberships(String listMemberScreenName, int count, long cursor, boolean filterToOwnedLists)
+            throws TwitterException;
+    
     /**
      * List the lists the specified user has been added to.
      * <br>This method calls https://api.twitter.com/1.1/lists/memberships.json
@@ -288,6 +350,23 @@ public interface ListsResources {
      * @since Twitter4J 2.2.4
      */
     PagableResponseList<UserList> getUserListMemberships(long listMemberId, long cursor, boolean filterToOwnedLists)
+            throws TwitterException;
+    
+    /**
+     * List the lists the specified user has been added to.
+     * <br>This method calls https://api.twitter.com/1.1/lists/memberships.json
+     *
+     * @param listMemberId       The id of the list member
+     * @param count The amount of results to return per page. No more than 1000 results will ever be returned in a single page.
+     * @param cursor             Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @param filterToOwnedLists Whether to return just lists the authenticating user owns, and the user represented by listMemberId is a member of.
+     * @return the list of lists
+     * @throws TwitterException      when Twitter service or network is unavailable
+     * @throws IllegalStateException when filerToOwnedLists is true but authorization is not enabled
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/memberships">GET lists/memberships | Twitter Developers</a>
+     * @since Twitter4J 2.2.4
+     */
+    PagableResponseList<UserList> getUserListMemberships(long listMemberId, int count, long cursor, boolean filterToOwnedLists)
             throws TwitterException;
 
     /**

--- a/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
@@ -1080,6 +1080,19 @@ public interface ListsResources {
      * <br>This method calls https://api.twitter.com/1.1/lists/ownerships.json
      *
      * @param listOwnerScreenName The screen name of the list owner
+     * @param cursor              Breaks the results into pages. Provide a value of -1 to begin paging. Provide values as returned in the response body's next_cursor and previous_cursor attributes to page back and forth in the list. It is recommended to always use cursors when the method supports them. See <a href="https://dev.twitter.com/docs/misc/cursoring">Using cursors</a> to navigate collections for more information.
+     * @return lists owned by the specified Twitter user
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<UserList> getUserListsOwnerships(String listOwnerScreenName, long cursor)
+            throws TwitterException;
+    
+    /**
+     * Returns the lists owned by the specified Twitter user. Private lists will only be shown if the authenticated user is also the owner of the lists.
+     * <br>This method calls https://api.twitter.com/1.1/lists/ownerships.json
+     *
+     * @param listOwnerScreenName The screen name of the list owner
      * @param count               The amount of results to return per page. Defaults to 20. No more than 1000 results will ever be returned in a single page.
      * @param cursor              Breaks the results into pages. Provide a value of -1 to begin paging. Provide values as returned in the response body's next_cursor and previous_cursor attributes to page back and forth in the list. It is recommended to always use cursors when the method supports them. See <a href="https://dev.twitter.com/docs/misc/cursoring">Using cursors</a> to navigate collections for more information.
      * @return lists owned by the specified Twitter user
@@ -1089,6 +1102,19 @@ public interface ListsResources {
     PagableResponseList<UserList> getUserListsOwnerships(String listOwnerScreenName, int count, long cursor)
             throws TwitterException;
 
+    /**
+     * Returns the lists owned by the specified Twitter user. Private lists will only be shown if the authenticated user is also the owner of the lists.
+     * <br>This method calls https://api.twitter.com/1.1/lists/ownerships.json
+     *
+     * @param listOwnerId The id of the list owner
+     * @param cursor      Breaks the results into pages. Provide a value of -1 to begin paging. Provide values as returned in the response body's next_cursor and previous_cursor attributes to page back and forth in the list. It is recommended to always use cursors when the method supports them. See <a href="https://dev.twitter.com/docs/misc/cursoring">Using cursors</a> to navigate collections for more information.
+     * @return lists owned by the specified Twitter user
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<UserList> getUserListsOwnerships(long listOwnerId, long cursor)
+            throws TwitterException;
+    
     /**
      * Returns the lists owned by the specified Twitter user. Private lists will only be shown if the authenticated user is also the owner of the lists.
      * <br>This method calls https://api.twitter.com/1.1/lists/ownerships.json

--- a/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
@@ -403,13 +403,13 @@ public interface ListsResources {
      * @param listId The id of the list
      * @param count Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
      * @param cursor Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
-     * @param skip_status When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @param skipStatus When set to either true, t or 1 statuses will not be included in the returned user objects.
      * @return the members of the specified list.
      * @throws twitter4j.TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscribers">GET lists/subscribers | Twitter Developers</a>
      * @since Twitter4J 4.0.4
      */
-    PagableResponseList<User> getUserListSubscribers(long listId, int count, long cursor, boolean skip_status) throws TwitterException;
+    PagableResponseList<User> getUserListSubscribers(long listId, int count, long cursor, boolean skipStatus) throws TwitterException;
 
     /**
      * Returns the subscribers of the specified list.
@@ -448,13 +448,13 @@ public interface ListsResources {
      * @param slug    slug of the list
      * @param count Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
      * @param cursor  Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
-     * @param skip_status When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @param skipStatus When set to either true, t or 1 statuses will not be included in the returned user objects.
      * @return the members of the specified list.
      * @throws twitter4j.TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscribers">GET lists/subscribers | Twitter Developers</a>
      * @since Twitter4J 4.0.4
      */
-    PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, int count, long cursor, boolean skip_status) throws TwitterException;
+    PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, int count, long cursor, boolean skipStatus) throws TwitterException;
     
     /**
      * Returns the subscribers of the specified list.
@@ -493,13 +493,13 @@ public interface ListsResources {
      * @param slug            slug of the list
      * @param count Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
      * @param cursor          Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
-     * @param skip_status     When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @param skipStatus     When set to either true, t or 1 statuses will not be included in the returned user objects.
      * @return the members of the specified list.
      * @throws twitter4j.TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscribers">GET lists/subscribers | Twitter Developers</a>
      * @since Twitter4J 4.0.4
      */
-    PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, int count, long cursor, boolean skip_status) throws TwitterException;
+    PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, int count, long cursor, boolean skipStatus) throws TwitterException;
 
     /**
      * Make the authenticated user follow the specified list.
@@ -774,13 +774,13 @@ public interface ListsResources {
      * @param listId The id of the list
      * @param count  Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
      * @param cursor Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
-     * @param skip_status When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @param skipStatus When set to either true, t or 1 statuses will not be included in the returned user objects.
      * @return the members of the specified list.
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/members">GET lists/members | Twitter Developers</a>
      * @since Twitter4J 4.0.4
      */
-    PagableResponseList<User> getUserListMembers(long listId, int count, long cursor, boolean skip_status)
+    PagableResponseList<User> getUserListMembers(long listId, int count, long cursor, boolean skipStatus)
             throws TwitterException;
 
     /**
@@ -822,13 +822,13 @@ public interface ListsResources {
      * @param slug    slug of the list
      * @param count   Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
      * @param cursor  Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
-     * @param skip_status When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @param skipStatus When set to either true, t or 1 statuses will not be included in the returned user objects.
      * @return the members of the specified list.
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/members">GET lists/members | Twitter Developers</a>
      * @since Twitter4J 4.0.4
      */
-    PagableResponseList<User> getUserListMembers(long ownerId, String slug, int count, long cursor, boolean skip_status)
+    PagableResponseList<User> getUserListMembers(long ownerId, String slug, int count, long cursor, boolean skipStatus)
             throws TwitterException;
 
     /**
@@ -870,13 +870,13 @@ public interface ListsResources {
      * @param slug            slug of the list
      * @param count           Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
      * @param cursor          Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
-     * @param skip_status     When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @param skipStatus     When set to either true, t or 1 statuses will not be included in the returned user objects.
      * @return the members of the specified list.
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/members">GET lists/members | Twitter Developers</a>
      * @since Twitter4J 4.0.4
      */
-    PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, int count, long cursor, boolean skip_status)
+    PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, int count, long cursor, boolean skipStatus)
             throws TwitterException;
 
     /**

--- a/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
@@ -381,6 +381,35 @@ public interface ListsResources {
      * @since Twitter4J 2.2.3
      */
     PagableResponseList<User> getUserListSubscribers(long listId, long cursor) throws TwitterException;
+    
+    /**
+     * Returns the subscribers of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/subscribers.json
+     *
+     * @param listId The id of the list
+     * @param count Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the members of the specified list.
+     * @throws twitter4j.TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscribers">GET lists/subscribers | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListSubscribers(long listId, int count, long cursor) throws TwitterException;
+    
+    /**
+     * Returns the subscribers of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/subscribers.json
+     *
+     * @param listId The id of the list
+     * @param count Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @param skip_status When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @return the members of the specified list.
+     * @throws twitter4j.TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscribers">GET lists/subscribers | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListSubscribers(long listId, int count, long cursor, boolean skip_status) throws TwitterException;
 
     /**
      * Returns the subscribers of the specified list.
@@ -395,7 +424,38 @@ public interface ListsResources {
      * @since Twitter4J 3.0.0
      */
     PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, long cursor) throws TwitterException;
+    
+    /**
+     * Returns the subscribers of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/subscribers.json
+     *
+     * @param ownerId The user ID of the user who owns the list being requested by a slug.
+     * @param slug    slug of the list
+     * @param count Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor  Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the members of the specified list.
+     * @throws twitter4j.TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscribers">GET lists/subscribers | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, int count, long cursor) throws TwitterException;
 
+    /**
+     * Returns the subscribers of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/subscribers.json
+     *
+     * @param ownerId The user ID of the user who owns the list being requested by a slug.
+     * @param slug    slug of the list
+     * @param count Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor  Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @param skip_status When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @return the members of the specified list.
+     * @throws twitter4j.TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscribers">GET lists/subscribers | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListSubscribers(long ownerId, String slug, int count, long cursor, boolean skip_status) throws TwitterException;
+    
     /**
      * Returns the subscribers of the specified list.
      * <br>This method calls https://api.twitter.com/1.1/lists/subscribers.json
@@ -409,6 +469,37 @@ public interface ListsResources {
      * @since Twitter4J 3.0.2
      */
     PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, long cursor) throws TwitterException;
+    
+    /**
+     * Returns the subscribers of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/subscribers.json
+     *
+     * @param ownerScreenName The screen name of the user who owns the list being requested by a slug.
+     * @param slug            slug of the list
+     * @param count Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor          Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the members of the specified list.
+     * @throws twitter4j.TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscribers">GET lists/subscribers | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, int count, long cursor) throws TwitterException;
+    
+    /**
+     * Returns the subscribers of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/subscribers.json
+     *
+     * @param ownerScreenName The screen name of the user who owns the list being requested by a slug.
+     * @param slug            slug of the list
+     * @param count Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor          Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @param skip_status     When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @return the members of the specified list.
+     * @throws twitter4j.TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscribers">GET lists/subscribers | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListSubscribers(String ownerScreenName, String slug, int count, long cursor, boolean skip_status) throws TwitterException;
 
     /**
      * Make the authenticated user follow the specified list.

--- a/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
@@ -751,6 +751,37 @@ public interface ListsResources {
      */
     PagableResponseList<User> getUserListMembers(long listId, long cursor)
             throws TwitterException;
+    
+    /**
+     * Returns the members of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/members.json
+     *
+     * @param listId The id of the list
+     * @param count  Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the members of the specified list.
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/members">GET lists/members | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListMembers(long listId, int count, long cursor)
+            throws TwitterException;
+    
+    /**
+     * Returns the members of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/members.json
+     *
+     * @param listId The id of the list
+     * @param count  Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @param skip_status When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @return the members of the specified list.
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/members">GET lists/members | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListMembers(long listId, int count, long cursor, boolean skip_status)
+            throws TwitterException;
 
     /**
      * Returns the members of the specified list.
@@ -766,6 +797,39 @@ public interface ListsResources {
      */
     PagableResponseList<User> getUserListMembers(long ownerId, String slug, long cursor)
             throws TwitterException;
+    
+    /**
+     * Returns the members of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/members.json
+     *
+     * @param ownerId The user ID of the user who owns the list being requested by a slug.
+     * @param slug    slug of the list
+     * @param count   Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor  Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the members of the specified list.
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/members">GET lists/members | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListMembers(long ownerId, String slug, int count, long cursor)
+            throws TwitterException;
+    
+    /**
+     * Returns the members of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/members.json
+     *
+     * @param ownerId The user ID of the user who owns the list being requested by a slug.
+     * @param slug    slug of the list
+     * @param count   Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor  Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @param skip_status When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @return the members of the specified list.
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/members">GET lists/members | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListMembers(long ownerId, String slug, int count, long cursor, boolean skip_status)
+            throws TwitterException;
 
     /**
      * Returns the members of the specified list.
@@ -780,6 +844,39 @@ public interface ListsResources {
      * @since Twitter4J 3.0.2
      */
     PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, long cursor)
+            throws TwitterException;
+    
+    /**
+     * Returns the members of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/members.json
+     *
+     * @param ownerScreenName The screen name of the user who owns the list being requested by a slug.
+     * @param slug            slug of the list
+     * @param count           Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor          Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the members of the specified list.
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/members">GET lists/members | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, int count, long cursor)
+            throws TwitterException;
+    
+    /**
+     * Returns the members of the specified list.
+     * <br>This method calls https://api.twitter.com/1.1/lists/members.json
+     *
+     * @param ownerScreenName The screen name of the user who owns the list being requested by a slug.
+     * @param slug            slug of the list
+     * @param count           Specifies the number of results to return per page. The default is 20, with a maximum of 5,000.
+     * @param cursor          Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @param skip_status     When set to either true, t or 1 statuses will not be included in the returned user objects.
+     * @return the members of the specified list.
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/members">GET lists/members | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<User> getUserListMembers(String ownerScreenName, String slug, int count, long cursor, boolean skip_status)
             throws TwitterException;
 
     /**

--- a/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
@@ -1065,14 +1065,58 @@ public interface ListsResources {
      * List the lists the specified user follows.
      * <br>This method calls https://api.twitter.com/1.1/lists/subscriptions.json
      *
-     * @param listOwnerScreenName The screen name of the list owner
+     * @param listSubscriberScreenName The screen name of the list subscriber
      * @param cursor              Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
-     * @return the list of lists
+     * @return the list of lists the specified user is subscribed to
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscriptions">GET lists/subscriptions | Twitter Developers</a>
      * @since Twitter4J 2.1.0
      */
-    PagableResponseList<UserList> getUserListSubscriptions(String listOwnerScreenName, long cursor)
+    PagableResponseList<UserList> getUserListSubscriptions(String listSubscriberScreenName, long cursor)
+            throws TwitterException;
+    
+    /**
+     * List the lists the specified user follows.
+     * <br>This method calls https://api.twitter.com/1.1/lists/subscriptions.json
+     *
+     * @param listSubscriberScreenName The screen name of the list subscriber
+     * @param count               The amount of results to return per page. Defaults to 20. No more than 1000 results will ever be returned in a single page.
+     * @param cursor              Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the list of lists the specified user is subscribed to
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscriptions">GET lists/subscriptions | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<UserList> getUserListSubscriptions(String listSubscriberScreenName, int count, long cursor)
+            throws TwitterException;
+    
+    /**
+     * List the lists the specified user follows.
+     * <br>This method calls https://api.twitter.com/1.1/lists/subscriptions.json
+     *
+     * @param listSubscriberId    The ID of the list subscriber
+     * @param cursor              Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the list of lists the specified user is subscribed to
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscriptions">GET lists/subscriptions | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<UserList> getUserListSubscriptions(long listSubscriberId, long cursor)
+            throws TwitterException;
+    
+    /**
+     * List the lists the specified user follows.
+     * <br>This method calls https://api.twitter.com/1.1/lists/subscriptions.json
+     *
+     * @param listOwnerScreenName The ID of the list subscriber
+     * @param count               The amount of results to return per page. Defaults to 20. No more than 1000 results will ever be returned in a single page.
+     * @param cursor              Breaks the results into pages. Provide a value of -1 to begin paging. Provide values as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @return the list of lists the specified user is subscribed to
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/subscriptions">GET lists/subscriptions | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    PagableResponseList<UserList> getUserListSubscriptions(long listSubscriberId, int count, long cursor)
             throws TwitterException;
 
     /**

--- a/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/ListsResources.java
@@ -35,6 +35,21 @@ public interface ListsResources {
      */
     ResponseList<UserList> getUserLists(String listOwnerScreenName)
             throws TwitterException;
+    
+    /**
+     * List the lists of the specified user. Private lists will be included if the authenticated users is the same as the user whose lists are being returned.
+     * <br>This method calls https://api.twitter.com/1.1/lists.json
+     *
+     * @param listOwnerScreenName The screen name of the list owner
+     *                            as returned to in the response body's next_cursor and previous_cursor attributes to page back and forth in the list.
+     * @param reverse Set this to true if you would like owned lists to be returned first
+     * @return the list of lists
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/list">GET lists/list | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    ResponseList<UserList> getUserLists(String listOwnerScreenName, boolean reverse)
+            throws TwitterException;
 
     /**
      * List the lists of the specified user. Private lists will be included if the authenticated users is the same as the user whose lists are being returned.
@@ -48,7 +63,20 @@ public interface ListsResources {
      */
     ResponseList<UserList> getUserLists(long listOwnerUserId)
             throws TwitterException;
-
+    
+    /**
+     * List the lists of the specified user. Private lists will be included if the authenticated users is the same as the user whose lists are being returned.
+     * <br>This method calls https://api.twitter.com/1.1/lists.json
+     *
+     * @param listOwnerUserId The id of the list owner
+     * @param reverse Set this to true if you would like owned lists to be returned first
+     * @return the list of lists
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/get/lists/list">GET lists/list | Twitter Developers</a>
+     * @since Twitter4J 4.0.4
+     */
+    ResponseList<UserList> getUserLists(long listOwnerUserId, boolean reverse)
+            throws TwitterException;
 
     /**
      * Show tweet timeline for members of the specified list.


### PR DESCRIPTION
reverse parameter for : https://dev.twitter.com/rest/reference/get/lists/list
count parameter for https://dev.twitter.com/rest/reference/get/lists/memberships
count & skip_status parameters for https://dev.twitter.com/rest/reference/get/lists/subscribers
count & skip_status parameters for https://dev.twitter.com/rest/reference/get/lists/members
count & user_id parameters for https://dev.twitter.com/rest/reference/get/lists/subscriptions

include_entities parameter not included, "will be made a default component of output in the future"

make "count" optional for getUserListsOwnerships https://dev.twitter.com/rest/reference/get/lists/ownerships