### PR TITLE
Fixed the omission which was happened when converting user_id from int to long.

### DIFF
--- a/twitter4j-core/src/test/java/twitter4j/TwitterTestBase.java
+++ b/twitter4j-core/src/test/java/twitter4j/TwitterTestBase.java
@@ -34,7 +34,7 @@ public class TwitterTestBase extends TestCase {
     protected final Properties p = new Properties();
 
     protected String numberId, numberPass, followsOneWay;
-    protected int numberIdId;
+    protected long numberIdId;
     protected TestUserInfo id1, id2, id3, bestFriend1, bestFriend2;
     protected Configuration conf1, conf2, conf3;
 
@@ -85,7 +85,7 @@ public class TwitterTestBase extends TestCase {
         numberId = p.getProperty("numberid.user");
         numberPass = p.getProperty("numberid.password");
 //        id1id = Integer.valueOf(p.getProperty("id1id"));
-        numberIdId = Integer.valueOf(p.getProperty("numberid.id"));
+        numberIdId = Long.valueOf(p.getProperty("numberid.id"));
 
         twitter1 = new TwitterFactory(conf1).getInstance();
 


### PR DESCRIPTION
TFJ-259 overlooked this.