### PR TITLE
Protect from npe when invoking shutdown on site stream

### DIFF
--- a/twitter4j-stream/src/main/java/twitter4j/StreamController.java
+++ b/twitter4j-stream/src/main/java/twitter4j/StreamController.java
@@ -46,7 +46,7 @@ public class StreamController {
     }
 
     void setControlURI(String controlURI) {
-        this.controlURI = controlURI.replace("/1.1//1.1/", "/1.1/");
+        this.controlURI = (controlURI!=null) ?controlURI.replace("/1.1//1.1/", "/1.1/") : null;
         synchronized (lock) {
             lock.notifyAll();
         }


### PR DESCRIPTION
When a sitestream is shut down the onClose event calls the StreamController.setControlURI with a null. This causes an npe error in the stream controller where it is assumed that the method will always be called with a valid string.