### PR TITLE
Add error message when no twitter4j.properties file

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -114,5 +114,6 @@ William Morgan <william at twitter.com> @wm
 William O'Hanley <william at wohanley.com> @wohanley
 William Vanderhoef <william.vanderhoef at gmail.com> @thePoofy
 withgod <noname at withgod.jp> @withgod
+Yuichiro Kawano <tresener.yu1ro at gmail.com> @tresener_yu1ro
 Yusuke Yamamoto <yusuke at mac.com> @yusuke
 Yuto Uehara <mumei.himazin at gmail.com> @mumei_himazin

--- a/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
@@ -33,7 +33,7 @@ import static twitter4j.HttpResponseCode.*;
  * @author Yusuke Yamamoto - yusuke at mac.com
  */
 abstract class TwitterBaseImpl implements TwitterBase, java.io.Serializable, OAuthSupport, OAuth2Support, HttpResponseListener {
-    private static final String WWW_DETAILS = "See http://twitter4j.org/en/configuration.html for details";
+    private static final String WWW_DETAILS = "See http://twitter4j.org/en/configuration.html for details. See and register at http://apps.twitter.com/";
     private static final long serialVersionUID = -7824361938865528554L;
 
     Configuration conf;


### PR DESCRIPTION
Hi.

When no twitter4j.properties file and haven't registered yet, I was very hard searching for this page.
So, I think this error message should have the link for register page for developers.
http://apps.twitter.com/
