### PR TITLE
Makes all implementation classes Serializable

### DIFF
--- a/twitter4j-core/src/internal-json/java/twitter4j/LanguageJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/LanguageJSONImpl.java
@@ -23,6 +23,7 @@ import twitter4j.conf.Configuration;
  * @since Twitter4J 2.2.3
  */
 public class LanguageJSONImpl implements HelpResources.Language {
+    private static final long serialVersionUID = 7494362811767097342L;
     private String name;
     private String code;
     private String status;

--- a/twitter4j-core/src/internal-json/java/twitter4j/ScopesImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/ScopesImpl.java
@@ -22,6 +22,7 @@ package twitter4j;
  * @since Twitter4J 3.0.6
  */
 public class ScopesImpl implements Scopes {
+    private static final long serialVersionUID = -6301829625595514787L;
 
     private final String[] placeIds;
     

--- a/twitter4j-core/src/main/java/twitter4j/api/HelpResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/HelpResources.java
@@ -21,6 +21,7 @@ import twitter4j.ResponseList;
 import twitter4j.TwitterAPIConfiguration;
 import twitter4j.TwitterException;
 
+import java.io.Serializable;
 import java.util.Map;
 
 /**
@@ -48,7 +49,7 @@ public interface HelpResources {
      */
     ResponseList<Language> getLanguages() throws TwitterException;
 
-    public interface Language {
+    public interface Language extends Serializable {
         String getName();
 
         String getCode();


### PR DESCRIPTION
This patch ensures that all *Impl classes under internal-json are Serializable.
Some classes referenced by Status not being Serializable was causing NotSerializableException when trying to serialize certain statuses.
I have not checked for the existence of other classes that are unserializable when they should be.