### PR TITLE
Adding email support

### DIFF
--- a/twitter4j-appengine/src/main/java/twitter4j/LazyUser.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/LazyUser.java
@@ -70,6 +70,15 @@ final class LazyUser implements twitter4j.User {
     public String getName() {
         return getTarget().getName();
     }
+    
+    /**
+     * Returns the email of the user
+     *
+     * @return the email of the user
+     */
+    public String getEmail() {
+        return getTarget().getEmail();
+    }
 
 
     /**

--- a/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
@@ -31,6 +31,7 @@ import java.util.Date;
     private static final long serialVersionUID = -5448266606847617015L;
     private long id;
     private String name;
+    private String email;
     private String screenName;
     private String location;
     private String description;
@@ -98,6 +99,7 @@ import java.util.Date;
         try {
             id = ParseUtil.getLong("id", json);
             name = ParseUtil.getRawString("name", json);
+            email = ParseUtil.getRawString("email", json);
             screenName = ParseUtil.getRawString("screen_name", json);
             location = ParseUtil.getRawString("location", json);
 
@@ -207,6 +209,11 @@ import java.util.Date;
     @Override
     public String getName() {
         return name;
+    }
+    
+    @Override
+    public String getEmail() {
+        return email;
     }
 
     @Override
@@ -559,6 +566,7 @@ import java.util.Date;
         return "UserJSONImpl{" +
                 "id=" + id +
                 ", name='" + name + '\'' +
+                ", email='" + email + '\'' +
                 ", screenName='" + screenName + '\'' +
                 ", location='" + location + '\'' +
                 ", description='" + description + '\'' +

--- a/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
@@ -125,8 +125,12 @@ abstract class TwitterBaseImpl implements TwitterBase, java.io.Serializable, OAu
     }
 
     User fillInIDAndScreenName() throws TwitterException {
+        return fillInIDAndScreenName(null);
+    }
+    
+    public User fillInIDAndScreenName(HttpParameter[] parameters) throws TwitterException {
         ensureAuthorizationEnabled();
-        User user = new UserJSONImpl(http.get(conf.getRestBaseURL() + "account/verify_credentials.json", null, auth, this), conf);
+        User user = new UserJSONImpl(http.get(conf.getRestBaseURL() + "account/verify_credentials.json", parameters, auth, this), conf);
         this.screenName = user.getScreenName();
         this.id = user.getId();
         return user;

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -577,6 +577,11 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     public User verifyCredentials() throws TwitterException {
         return super.fillInIDAndScreenName();
     }
+    
+    @Override
+    public User verifyCredentials(HttpParameter[] parameters) throws TwitterException {
+        return super.fillInIDAndScreenName(parameters);
+    }
 
     @Override
     public AccountSettings updateAccountSettings(Integer trend_locationWoeid,

--- a/twitter4j-core/src/main/java/twitter4j/User.java
+++ b/twitter4j-core/src/main/java/twitter4j/User.java
@@ -37,6 +37,13 @@ public interface User extends Comparable<User>, TwitterResponse, java.io.Seriali
      * @return the name of the user
      */
     String getName();
+    
+    /**
+     * Returns the email of the user, if the app is whitelisted by Twitter
+     *
+     * @return the email of the user
+     */
+    String getEmail();
 
     /**
      * Returns the screen name of the user

--- a/twitter4j-core/src/main/java/twitter4j/api/UsersResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/UsersResources.java
@@ -47,6 +47,7 @@ public interface UsersResources {
      * @since Twitter4J 2.0.0
      */
     User verifyCredentials() throws TwitterException;
+    User verifyCredentials(HttpParameter[] parameters) throws TwitterException;
 
     /**
      * Updates the current trend, geo, language, timezone and sleep time information for the authenticating user.


### PR DESCRIPTION
As per their documentation, Twitter started to include the user email on the verify request endpoint.
https://dev.twitter.com/rest/reference/get/account/verify_credentials
This PR includes a way for the library users to send parameters to the verify_credentials endpoint to request the user email