### PR TITLE
Add support for video related parameters (widget_type and hide_tweet)…

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/OEmbedRequest.java
+++ b/twitter4j-core/src/main/java/twitter4j/OEmbedRequest.java
@@ -35,6 +35,8 @@ public final class OEmbedRequest implements Serializable {
     private Align align = Align.NONE;
     private String[] related = {};
     private String lang;
+    private WidgetType widgetType = WidgetType.NONE;
+    private boolean hideTweet = false;
 
     public OEmbedRequest(long statusId, String url) {
         this.statusId = statusId;
@@ -104,10 +106,34 @@ public final class OEmbedRequest implements Serializable {
         return this;
     }
 
+    public void setWidgetType(WidgetType widgetType) {
+        this.widgetType = widgetType;
+    }
+
+    public OEmbedRequest widgetType(WidgetType widgetType) {
+        this.widgetType = widgetType;
+        return this;
+    }
+
+    public void setHideTweet(boolean hideTweet) {
+        this.hideTweet = hideTweet;
+    }
+
+    public OEmbedRequest hideTweet(boolean hideTweet) {
+        this.hideTweet = hideTweet;
+        return this;
+    }
+
+
     public enum Align {
         LEFT,
         CENTER,
         RIGHT,
+        NONE
+    }
+
+    public enum WidgetType {
+        VIDEO,
         NONE
     }
 
@@ -124,6 +150,11 @@ public final class OEmbedRequest implements Serializable {
             appendParameter("related", StringUtil.join(related), params);
         }
         appendParameter("lang", lang, params);
+        if(widgetType != WidgetType.NONE) {
+            params.add(new HttpParameter("widget_type", widgetType.name().toLowerCase()));
+            params.add(new HttpParameter("hide_tweet", hideTweet));
+        }
+
         HttpParameter[] paramArray = new HttpParameter[params.size()];
         return params.toArray(paramArray);
     }
@@ -156,6 +187,8 @@ public final class OEmbedRequest implements Serializable {
         if (lang != null ? !lang.equals(that.lang) : that.lang != null) return false;
         if (!Arrays.equals(related, that.related)) return false;
         if (url != null ? !url.equals(that.url) : that.url != null) return false;
+        if (widgetType != that.widgetType) return false;
+        if (hideTweet != that.hideTweet) return false;
 
         return true;
     }
@@ -171,6 +204,8 @@ public final class OEmbedRequest implements Serializable {
         result = 31 * result + (align != null ? align.hashCode() : 0);
         result = 31 * result + (related != null ? Arrays.hashCode(related) : 0);
         result = 31 * result + (lang != null ? lang.hashCode() : 0);
+        result = 31 * result + (widgetType != null ? widgetType.hashCode() : 0);
+        result = 31 * result + (hideTweet ? 1 : 0);
         return result;
     }
 
@@ -186,6 +221,8 @@ public final class OEmbedRequest implements Serializable {
                 ", align=" + align +
                 ", related=" + (related == null ? null : Arrays.asList(related)) +
                 ", lang='" + lang + '\'' +
+                ", widgetType=" + widgetType +
+                ", hideTweet=" + hideTweet +
                 '}';
     }
 }

--- a/twitter4j-core/src/test/java/twitter4j/TweetsResourcesTest.java
+++ b/twitter4j-core/src/test/java/twitter4j/TweetsResourcesTest.java
@@ -15,6 +15,8 @@
  */
 package twitter4j;
 
+import org.junit.Ignore;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.List;
@@ -155,6 +157,30 @@ public class TweetsResourcesTest extends TwitterTestBase {
         assertTrue(0 < oembed.getWidth());
 
         oembed = twitter1.getOEmbed(new OEmbedRequest(273685580615913473L, "http://samuraism.com/"));
+
+    }
+
+    // kept ignored since should setup a tweet with video for whatever user you have in test.properties id1.*
+    // and plug that id in below.
+    @Ignore
+    public void testOEmbedWithWidgetType() throws TwitterException {
+        // to use this as a test for new widget type do the following: put a status id that represents a tweet with
+        // video for the user account configured as id1 in test.properties
+        long REPLACE_ME_WITH_VALID_STATUS_ID_FOR_TWEET_WITH_VIDEO = 0;
+        OEmbedRequest req = new OEmbedRequest(REPLACE_ME_WITH_VALID_STATUS_ID_FOR_TWEET_WITH_VIDEO, "");
+        req.setWidgetType(OEmbedRequest.WidgetType.VIDEO);
+        // use this if want to see impact:
+        // req.setHideTweet(true);
+
+        OEmbed oembed = twitter1.getOEmbed(req);
+
+        assertNotNull(TwitterObjectFactory.getRawJSON(oembed));
+        assertEquals(oembed, TwitterObjectFactory.createOEmbed(TwitterObjectFactory.getRawJSON(oembed)));
+
+        assertNotNull(oembed.getHtml());
+        assertTrue(oembed.getHtml().contains("<blockquote class=\"twitter-video\""));
+        // use this assert if include req.setHideTweet(true)
+        // assertTrue(oembed.getHtml().contains("<blockquote class=\"twitter-video\" data-status=\"hidden\""));
 
     }
 


### PR DESCRIPTION
Add support for video related parameters twitter added for the statuses/oembed api call.  The two params are: widget_type and hide_tweet.  
See: https://dev.twitter.com/rest/reference/get/statuses/oembed  

Without the widget_type param there is no way to get just the embed code to show video only rather than the entire tweet.  
