### PR TITLE
Fix thread sync bug in HttpClientFactory

### DIFF
--- a/twitter4j-core/src/internal-http/java/twitter4j/HttpClientFactory.java
+++ b/twitter4j-core/src/internal-http/java/twitter4j/HttpClientFactory.java
@@ -20,7 +20,7 @@ import twitter4j.conf.ConfigurationContext;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Yusuke Yamamoto - yusuke at mac.com
@@ -60,7 +60,7 @@ public final class HttpClientFactory {
         }
     }
 
-    private final static HashMap<HttpClientConfiguration, HttpClient> confClientMap = new HashMap<HttpClientConfiguration, HttpClient>();
+    private final static ConcurrentHashMap<HttpClientConfiguration, HttpClient> confClientMap = new ConcurrentHashMap<HttpClientConfiguration, HttpClient>();
 
     public static HttpClient getInstance() {
         return getInstance(ConfigurationContext.getInstance().getHttpClientConfiguration());


### PR DESCRIPTION
`HttpClientFactory` is using a `HashMap` for storing an `HttpClient` instance per `HttpClientConfiguration`.
When multiple threads are invoking `HttpClientFactory.getInstance()`, some may run into an infinite loop (see [JDK-7027300](http://bugs.java.com/view_bug.do?bug_id=7027300)).

Using a `ConcurrentHashMap` solves the issue.

Example stack trace:
```
"thread-2" prio=10 tid=0x00007fe2a0e53000 nid=0x2db3 runnable [0x00007fe22f1ef000]
   java.lang.Thread.State: RUNNABLE
        at java.util.HashMap.getEntry(HashMap.java:465)
        at java.util.HashMap.get(HashMap.java:417)
        at twitter4j.HttpClientFactory.getInstance(HttpClientFactory.java:70)
        at twitter4j.auth.OAuthAuthorization.<init>(OAuthAuthorization.java:56)
        at twitter4j.TwitterFactory.getInstance(TwitterFactory.java:143)
        ...

"thread-1" prio=10 tid=0x00007fe2a0e4c800 nid=0x2db2 runnable [0x00007fe22f2f0000]
   java.lang.Thread.State: RUNNABLE
        at java.util.HashMap.getEntry(HashMap.java:465)
        at java.util.HashMap.get(HashMap.java:417)
        at twitter4j.HttpClientFactory.getInstance(HttpClientFactory.java:70)
        at twitter4j.auth.OAuthAuthorization.<init>(OAuthAuthorization.java:56)
        at twitter4j.TwitterFactory.getInstance(TwitterFactory.java:143)
		...
```