### PR TITLE
Add support for getting email address from Twitter user

### DIFF
--- a/twitter4j-appengine/src/main/java/twitter4j/LazyUser.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/LazyUser.java
@@ -71,6 +71,14 @@ final class LazyUser implements twitter4j.User {
         return getTarget().getName();
     }
 
+    /**
+     * Returns the email of the user
+     *
+     * @return the email of the user
+     */
+    public String getEmail() {
+        return getTarget().getEmail();
+    }
 
     /**
      * Returns the screen name of the user

--- a/twitter4j-core/src/internal-json/java/twitter4j/ParseUtil.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/ParseUtil.java
@@ -50,6 +50,8 @@ final class ParseUtil {
             }
         } catch (JSONException jsone) {
             return null;
+        } catch (Exception ex) {
+            return null;
         }
     }
 

--- a/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
@@ -31,6 +31,7 @@ import java.util.Date;
     private static final long serialVersionUID = -5448266606847617015L;
     private long id;
     private String name;
+    private String email;
     private String screenName;
     private String location;
     private String description;
@@ -98,6 +99,7 @@ import java.util.Date;
         try {
             id = ParseUtil.getLong("id", json);
             name = ParseUtil.getRawString("name", json);
+            email = ParseUtil.getRawString("email", json);
             screenName = ParseUtil.getRawString("screen_name", json);
             location = ParseUtil.getRawString("location", json);
 
@@ -207,6 +209,11 @@ import java.util.Date;
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
     }
 
     @Override
@@ -559,6 +566,7 @@ import java.util.Date;
         return "UserJSONImpl{" +
                 "id=" + id +
                 ", name='" + name + '\'' +
+                ", email='" + email + '\'' +
                 ", screenName='" + screenName + '\'' +
                 ", location='" + location + '\'' +
                 ", description='" + description + '\'' +

--- a/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterBaseImpl.java
@@ -126,7 +126,13 @@ abstract class TwitterBaseImpl implements TwitterBase, java.io.Serializable, OAu
 
     User fillInIDAndScreenName() throws TwitterException {
         ensureAuthorizationEnabled();
-        User user = new UserJSONImpl(http.get(conf.getRestBaseURL() + "account/verify_credentials.json", null, auth, this), conf);
+
+        HttpParameter[] parameters = null;
+        if (conf.isIncludeEmailEnabled()) {
+            parameters = new HttpParameter[] { new HttpParameter("include_email", true) };
+        }
+
+        User user = new UserJSONImpl(http.get(conf.getRestBaseURL() + "account/verify_credentials.json", parameters, auth, this), conf);
         this.screenName = user.getScreenName();
         this.id = user.getId();
         return user;

--- a/twitter4j-core/src/main/java/twitter4j/User.java
+++ b/twitter4j-core/src/main/java/twitter4j/User.java
@@ -39,6 +39,13 @@ public interface User extends Comparable<User>, TwitterResponse, java.io.Seriali
     String getName();
 
     /**
+     * Returns the email of the user
+     *
+     * @return the email of the user
+     */
+    String getEmail();
+
+    /**
      * Returns the screen name of the user
      *
      * @return the screen name of the user

--- a/twitter4j-core/src/main/java/twitter4j/conf/Configuration.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/Configuration.java
@@ -113,6 +113,8 @@ public interface Configuration extends AuthorizationConfiguration, java.io.Seria
 
     boolean isIncludeEntitiesEnabled();
 
+    boolean isIncludeEmailEnabled();
+
     boolean isTrimUserEnabled();
 
     boolean isDaemonEnabled();

--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
@@ -71,6 +71,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
 
     private boolean includeMyRetweetEnabled = true;
     private boolean includeEntitiesEnabled = true;
+    private boolean includeEmailEnabled = false;
     private boolean trimUserEnabled = false;
 
     private boolean jsonStoreEnabled = false;
@@ -594,6 +595,15 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
         this.includeEntitiesEnabled = includeEntitiesEnabled;
     }
 
+    @Override
+    public boolean isIncludeEmailEnabled() {
+        return includeEmailEnabled;
+    }
+
+    protected void setIncludeEmailEnabled(boolean includeEmailEnabled) {
+        this.includeEmailEnabled = includeEmailEnabled;
+    }
+
     protected final void setLoggerFactory(String loggerImpl) {
         this.loggerFactory = loggerImpl;
     }
@@ -738,6 +748,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
         if (httpRetryIntervalSeconds != that.httpRetryIntervalSeconds) return false;
         if (httpStreamingReadTimeout != that.httpStreamingReadTimeout) return false;
         if (includeEntitiesEnabled != that.includeEntitiesEnabled) return false;
+        if (includeEmailEnabled != that.includeEmailEnabled) return false;
         if (includeMyRetweetEnabled != that.includeMyRetweetEnabled) return false;
         if (jsonStoreEnabled != that.jsonStoreEnabled) return false;
         if (mbeanEnabled != that.mbeanEnabled) return false;
@@ -829,6 +840,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
         result = 31 * result + (int) (contributingTo ^ (contributingTo >>> 32));
         result = 31 * result + (includeMyRetweetEnabled ? 1 : 0);
         result = 31 * result + (includeEntitiesEnabled ? 1 : 0);
+        result = 31 * result + (includeEmailEnabled ? 1 : 0);
         result = 31 * result + (trimUserEnabled ? 1 : 0);
         result = 31 * result + (jsonStoreEnabled ? 1 : 0);
         result = 31 * result + (mbeanEnabled ? 1 : 0);
@@ -877,6 +889,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 ", contributingTo=" + contributingTo +
                 ", includeMyRetweetEnabled=" + includeMyRetweetEnabled +
                 ", includeEntitiesEnabled=" + includeEntitiesEnabled +
+                ", includeEmailEnabled=" + includeEmailEnabled +
                 ", trimUserEnabled=" + trimUserEnabled +
                 ", jsonStoreEnabled=" + jsonStoreEnabled +
                 ", mbeanEnabled=" + mbeanEnabled +

--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBuilder.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBuilder.java
@@ -264,6 +264,12 @@ public final class ConfigurationBuilder {
         return this;
     }
 
+    public ConfigurationBuilder setIncludeEmailEnabled(boolean enabled) {
+        checkNotBuilt();
+        configurationBean.setIncludeEmailEnabled(enabled);
+        return this;
+    }
+
     public ConfigurationBuilder setJSONStoreEnabled(boolean enabled) {
         checkNotBuilt();
         configurationBean.setJSONStoreEnabled(enabled);

--- a/twitter4j-core/src/main/java/twitter4j/conf/PropertyConfiguration.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/PropertyConfiguration.java
@@ -72,6 +72,7 @@ public final class PropertyConfiguration extends ConfigurationBase implements ja
     private static final String ASYNC_DISPATCHER_IMPL = "async.dispatcherImpl";
     private static final String INCLUDE_MY_RETWEET = "includeMyRetweet";
     private static final String INCLUDE_ENTITIES = "includeEntities";
+    private static final String INCLUDE_EMAIL = "includeEmail";
     private static final String LOGGER_FACTORY = "loggerFactory";
     private static final String JSON_STORE_ENABLED = "jsonStoreEnabled";
     private static final String MBEAN_ENABLED = "mbeanEnabled";
@@ -347,6 +348,9 @@ public final class PropertyConfiguration extends ConfigurationBase implements ja
         }
         if (notNull(props, prefix, INCLUDE_ENTITIES)) {
             setIncludeEntitiesEnabled(getBoolean(props, prefix, INCLUDE_ENTITIES));
+        }
+        if (notNull(props, prefix, INCLUDE_EMAIL)) {
+            setIncludeEmailEnabled(getBoolean(props, prefix, INCLUDE_EMAIL));
         }
         if (notNull(props, prefix, LOGGER_FACTORY)) {
             setLoggerFactory(getString(props, prefix, LOGGER_FACTORY));


### PR DESCRIPTION
I propose a better approach than #220 for getting the email address of a Twitter user using the Twitter REST API endpoint [_GET account/verify_credentials_](https://dev.twitter.com/rest/reference/get/account/verify_credentials)

Because requesting a user's email address requires that Twitter whitelists the application the user signs into I made the inclusion of the include_email parameter configurable through either:
1. twitter4j.properties file, by setting the includeEmail property to true
2. ConfigurationBuilder , by calling the setIncludeEmailEnabled(true) method on it
```java
ConfigurationBuilder builder = new ConfigurationBuilder();
builder.setOAuthConsumerKey(cKey);
builder.setOAuthConsumerSecret(cSecret);
builder.setOAuthAccessToken(accessToken.getToken());
builder.setOAuthAccessTokenSecret(accessToken.getTokenSecret());
builder.setIncludeEmailEnabled(true);

Twitter twitter = new TwitterFactory(builder.build()).getInstance();
try {
    User user = twitter.verifyCredentials();
    if (user != null)
    {
        mUserName = user.getName();
        mUserNickName = user.getScreenName();
        mUserId = String.valueOf(user.getId());
        mEmail = user.getEmail();

        Log.debug(TwitterManager.class, "TwitterManager.VerifyCredentials(): user_name = " + mUserName +
                ", user_nick_name = " + mUserNickName +
                ", user_id = " + mUserId +
                ", user_email = " + mEmail);
    }
} catch (TwitterException e) {
        Log.error(TwitterManager.class , "TwitterManager.VerifyCredentials error: " + e.getMessage());
        e.printStackTrace();
}
```

* The includeEmailEnabled parameter in ConfigurationBase is **false** by default because the email is only included in the response after a Twitter application has been whitelisted, thus it should only be sent to Twitter explicitly by each individual application.
* The commit about ensuring null is returned from ParseUtils.getRawString has been added because a user of twitter4j library can set includeEmail to true, but his application is not whitelisted, therefore there is no email returned in the JSON response and [JsonObject.getString](https://docs.oracle.com/javaee/7/api/javax/json/JsonObject.html#getString-java.lang.String-) method raises NullPointerException, and if we catch JsonException the exception will only be handled upstream in the UserJSONImpl::init method, which throws it further upstream. This is not what we want.  
I've used catch Exception class because JsonObject.getString can also raise ClassCastException, see [here](https://gist.github.com/mnemonicflow/f22cd674f55867fd680c) for a test case