### PR TITLE
Add property for "tweet_volume" to Trend, YouTrack Issue #TFJ-886

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,7 @@ Linker Lin <linker.lin at live.com>
 Ludovico Fischer @ludovicofischer
 marr-masaaki <marr fiveflavors at gmail.com> @marr
 matsumo <matsumo at ce.ns0.it> @sardinej
+Mathias Kahl <mathias.kahl at gmail.com> @Bunkerbewohner1
 Matteo Nicoletti <matteo at kaosmos.it> @kaosmos
 Matteo Villa @mttvll
 Max Penet <m at qbits.cc> @mpenet

--- a/twitter4j-core/src/internal-json/java/twitter4j/TrendJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/TrendJSONImpl.java
@@ -27,11 +27,13 @@ package twitter4j;
     private final String name;
     private String url = null;
     private String query = null;
+    private int tweetVolume = 0;
 
     /*package*/ TrendJSONImpl(JSONObject json, boolean storeJSON) {
         this.name = ParseUtil.getRawString("name", json);
         this.url = ParseUtil.getRawString("url", json);
         this.query = ParseUtil.getRawString("query", json);
+        this.tweetVolume = ParseUtil.getInt("tweet_volume", json);
         if (storeJSON) {
             TwitterObjectFactory.registerJSONObject(this, json);
         }
@@ -57,6 +59,11 @@ package twitter4j;
     }
 
     @Override
+    public int getTweetVolume() {
+        return tweetVolume;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Trend)) return false;
@@ -68,15 +75,18 @@ package twitter4j;
             return false;
         if (url != null ? !url.equals(trend.getURL()) : trend.getURL() != null)
             return false;
+        if (tweetVolume != trend.getTweetVolume())
+            return false;
 
         return true;
     }
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
+        int result = name != null ? name.hashCode() : 0;
         result = 31 * result + (url != null ? url.hashCode() : 0);
         result = 31 * result + (query != null ? query.hashCode() : 0);
+        result = 31 * result + tweetVolume;
         return result;
     }
 
@@ -86,6 +96,7 @@ package twitter4j;
                 "name='" + name + '\'' +
                 ", url='" + url + '\'' +
                 ", query='" + query + '\'' +
+                ", tweet_volume=" + tweetVolume +
                 '}';
     }
 }

--- a/twitter4j-core/src/internal-json/java/twitter4j/TrendJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/TrendJSONImpl.java
@@ -27,7 +27,7 @@ package twitter4j;
     private final String name;
     private String url = null;
     private String query = null;
-    private int tweetVolume = 0;
+    private int tweetVolume = -1;
 
     /*package*/ TrendJSONImpl(JSONObject json, boolean storeJSON) {
         this.name = ParseUtil.getRawString("name", json);

--- a/twitter4j-core/src/main/java/twitter4j/Trend.java
+++ b/twitter4j-core/src/main/java/twitter4j/Trend.java
@@ -30,4 +30,8 @@ public interface Trend extends java.io.Serializable {
 
     String getQuery();
 
+    /**
+     * The tweet volume for the last 24 hours if availabe, -1 otherwise.
+     */
+    int getTweetVolume();
 }

--- a/twitter4j-examples/src/main/java/twitter4j/examples/trends/GetPlaceTrends.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/trends/GetPlaceTrends.java
@@ -1,0 +1,40 @@
+package twitter4j.examples.trends;
+
+import twitter4j.*;
+
+/**
+ * Shows the trend for a place denoted by its WOEID. By default shows trends for "Worldwide" (WOEID 1).
+ *
+ * @author Mathias Kahl - mathias.kahl at gmail.com
+ */
+public final class GetPlaceTrends {
+    /**
+     * Usage: java twitter4j.examples.trends.GetPlaceTrends [WOEID=0]
+     *
+     * @param args message
+     */
+    public static void main(String[] args) {
+        try {
+            int woeid = args.length > 0 ? Integer.parseInt(args[0]) : 1;
+            Twitter twitter = new TwitterFactory().getInstance();
+            Trends trends = twitter.getPlaceTrends(woeid);
+
+            System.out.println("Showing trends for " + trends.getLocation().getName());
+
+            for (Trend trend : trends.getTrends()) {
+                System.out.println(String.format("%s (tweet_volume: %d)", trend.getName(), trend.getTweetVolume()));
+            }
+
+            System.out.println("done.");
+            System.exit(0);
+        } catch (TwitterException te) {
+            te.printStackTrace();
+            System.out.println("Failed to get trends: " + te.getMessage());
+            System.exit(-1);
+        } catch (NumberFormatException nfe) {
+            nfe.printStackTrace();
+            System.out.println("WOEID must be number");
+            System.exit(-1);
+        }
+    }
+}


### PR DESCRIPTION
[/trends/place](https://dev.twitter.com/rest/reference/get/trends/place) includes a "tweet_volume" for each trend (which may be -1).

Added the property to Trend interface and implementation. Additionally added an example to test/show that it works.

http://issue.twitter4j.org/youtrack/issue/TFJ-886
