### PR TITLE
support "video_info" for direct messages

### DIFF
--- a/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageJSONImpl.java
@@ -112,7 +112,13 @@ import java.util.Date;
                     len = mediaArray.length();
                     mediaEntities = new MediaEntity[len];
                     for (int i = 0; i < len; i++) {
-                        mediaEntities[i] = new MediaEntityJSONImpl(mediaArray.getJSONObject(i));
+
+                        final JSONObject mediaJson = mediaArray.getJSONObject(i);
+                        if (mediaJson.has("video_info")) {
+                            mediaEntities[i] = new ExtendedMediaEntityJSONImpl(mediaJson);
+                        } else {
+                            mediaEntities[i] = new MediaEntityJSONImpl(mediaJson);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
support "video_info" for Direct Messages

----

Status(Tweet) の場合は ```extended_entities``` に ```video_info``` を含みますが、どうやら DirectMessage の場合は ```media``` に直接 ```video_info``` が載るようです。

最近、DMにもGIF画像検索対応(スタンプのような用途のアレ)が行われたためかカジュアルにGIF画像がやり取りされているようで、DMの添付GIF画像を再生したいという要望が多くなっています。

```json
{
  "sender_id_str": "1565770556",
  "sender": {
    "location": "Japan",
    "default_profile": false,
    "profile_background_tile": true,
    "statuses_count": 1087,
    "lang": "ja",
    "profile_link_color": "038543",
    "profile_banner_url": "https:\/\/pbs.twimg.com\/profile_banners\/1565770556\/1398448782",
    "id": 1565770556,
    "following": false,
    "protected": false,
    "favourites_count": 35,
    "profile_text_color": "333333",
    "description": "Android用TwitterクライアントTwitPaneの公式アカウントです。\n\nOfficial account of TwitPane - Twitter client for Android",
    "verified": false,
    "contributors_enabled": false,
    "profile_sidebar_border_color": "FFFFFF",
    "name": "TwitPane(ついっとぺーん)",
    "profile_background_color": "E8F7F5",
    "created_at": "Wed Jul 03 13:18:32 +0000 2013",
    "is_translation_enabled": false,
    "default_profile_image": false,
    "followers_count": 820,
    "has_extended_profile": false,
    "profile_image_url_https": "https:\/\/pbs.twimg.com\/profile_images\/378800000255995784\/8a1a17fc7f87c5d4b7cc19a8c16e124a_normal.png",
    "geo_enabled": false,
    "profile_background_image_url": "http:\/\/pbs.twimg.com\/profile_background_images\/438585410353000448\/6w_JibUW.png",
    "profile_background_image_url_https": "https:\/\/pbs.twimg.com\/profile_background_images\/438585410353000448\/6w_JibUW.png",
    "follow_request_sent": false,
    "entities": {
      "description": {
        "urls": []
      },
      "url": {
        "urls": [
          {
            "expanded_url": "http:\/\/www.twitpane.com\/",
            "indices": [
              0,
              22
            ],
            "display_url": "twitpane.com",
            "url": "http:\/\/t.co\/5ScjgVR4QR"
          }
        ]
      }
    },
    "url": "http:\/\/t.co\/5ScjgVR4QR",
    "utc_offset": 32400,
    "time_zone": "Tokyo",
    "notifications": false,
    "profile_use_background_image": true,
    "friends_count": 19,
    "profile_sidebar_fill_color": "DDEEF6",
    "screen_name": "twitpane",
    "id_str": "1565770556",
    "profile_image_url": "http:\/\/pbs.twimg.com\/profile_images\/378800000255995784\/8a1a17fc7f87c5d4b7cc19a8c16e124a_normal.png",
    "listed_count": 50,
    "is_translator": false
  },
  "id": 709751660386451459,
  "text": "test https:\/\/t.co\/25eLExmVOL",
  "recipient_screen_name": "takke",
  "sender_id": 1565770556,
  "recipient_id": 8379212,
  "sender_screen_name": "twitpane",
  "created_at": "Tue Mar 15 14:42:37 +0000 2016",
  "id_str": "709751660386451459",
  "entities": {
    "symbols": [],
    "urls": [
      {
        "expanded_url": "https:\/\/twitter.com\/messages\/media\/709751660386451459",
        "indices": [
          5,
          28
        ],
        "display_url": "pic.twitter.com\/25eLExmVOL",
        "url": "https:\/\/t.co\/25eLExmVOL"
      }
    ],
    "hashtags": [],
    "media": [
      {
        "sizes": {
          "thumb": {
            "w": 150,
            "resize": "crop",
            "h": 150
          },
          "small": {
            "w": 320,
            "resize": "fit",
            "h": 168
          },
          "medium": {
            "w": 320,
            "resize": "fit",
            "h": 168
          },
          "large": {
            "w": 320,
            "resize": "fit",
            "h": 168
          }
        },
        "id": 709751639553347585,
        "media_url_https": "https:\/\/pbs.twimg.com\/dm_gif_preview\/709751639553347585\/xmBpq9k233wM0mXUXF73LwGv_fiMH2hYabd9v8ia2O2W5uh8vx.jpg",
        "video_info": {
          "variants": [
            {
              "bitrate": 0,
              "content_type": "video\/mp4",
              "url": "https:\/\/pbs.twimg.com\/dm_gif\/709751639553347585\/xmBpq9k233wM0mXUXF73LwGv_fiMH2hYabd9v8ia2O2W5uh8vx.mp4"
            }
          ],
          "aspect_ratio": [
            40,
            21
          ]
        },
        "media_url": "https:\/\/pbs.twimg.com\/dm_gif_preview\/709751639553347585\/xmBpq9k233wM0mXUXF73LwGv_fiMH2hYabd9v8ia2O2W5uh8vx.jpg",
        "expanded_url": "https:\/\/twitter.com\/messages\/media\/709751660386451459",
        "indices": [
          5,
          28
        ],
        "id_str": "709751639553347585",
        "type": "animated_gif",
        "display_url": "pic.twitter.com\/25eLExmVOL",
        "url": "https:\/\/t.co\/25eLExmVOL"
      }
    ],
    "user_mentions": []
  },
  "recipient_id_str": "8379212",
  "recipient": {
    "location": "北海道",
    "default_profile": true,
    "profile_background_tile": false,
    "statuses_count": 40420,
    "lang": "ja",
    "profile_link_color": "0084B4",
    "profile_banner_url": "https:\/\/pbs.twimg.com\/profile_banners\/8379212\/1390720101",
    "id": 8379212,
    "following": true,
    "protected": false,
    "favourites_count": 5319,
    "profile_text_color": "333333",
    "description": "TwitterクライアントTwitPane、FacebookブラウザTafView、mixiブラウザTkMixiViewer、英単語学習ソフト P-Study System 、MZ3\/4 などを開発。「ちょっぴり使いやすい」アプリを日々開発しています。ペーンクラフト代表",
    "verified": false,
    "contributors_enabled": false,
    "profile_sidebar_border_color": "C0DEED",
    "name": "竹内裕昭",
    "profile_background_color": "C0DEED",
    "created_at": "Thu Aug 23 10:06:53 +0000 2007",
    "is_translation_enabled": false,
    "default_profile_image": false,
    "followers_count": 1567,
    "has_extended_profile": false,
    "profile_image_url_https": "https:\/\/pbs.twimg.com\/profile_images\/423153841505193984\/yGKSJu78_normal.jpeg",
    "geo_enabled": true,
    "profile_background_image_url": "http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png",
    "profile_background_image_url_https": "https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png",
    "follow_request_sent": false,
    "entities": {
      "description": {
        "urls": []
      },
      "url": {
        "urls": [
          {
            "expanded_url": "http:\/\/www.panecraft.net",
            "indices": [
              0,
              23
            ],
            "display_url": "panecraft.net",
            "url": "https:\/\/t.co\/8al23JWsCZ"
          }
        ]
      }
    },
    "url": "https:\/\/t.co\/8al23JWsCZ",
    "utc_offset": 32400,
    "time_zone": "Tokyo",
    "notifications": false,
    "profile_use_background_image": true,
    "friends_count": 954,
    "profile_sidebar_fill_color": "DDEEF6",
    "screen_name": "takke",
    "id_str": "8379212",
    "profile_image_url": "http:\/\/pbs.twimg.com\/profile_images\/423153841505193984\/yGKSJu78_normal.jpeg",
    "listed_count": 132,
    "is_translator": false
  }
}
```
