### PR TITLE
added missing geoCode method and doc fixes

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,7 @@ Daniel Huckaby <handlerexploit at gmail.com> @HandlerExploit
 Denis Bardadym <bardadymchik at gmail.com> @bardadymchik
 Dong Wang <dong at twitter.com> @dongwang218
 Eli Israel <eli at meshfire.com> @eliasisrael
+Enrico Candino <enrico.candino at gmail.com> @enrichmann
 Eric Jensen <ej at twitter.com> @ej
 Fiaz Hossain <fiaz at twitter.com> @fiazhossain
 Gabriel Zanetti @pupi1985

--- a/twitter4j-core/src/main/java/twitter4j/Query.java
+++ b/twitter4j-core/src/main/java/twitter4j/Query.java
@@ -357,7 +357,7 @@ public final class Query implements java.io.Serializable {
      *
      * @param location geo location
      * @param radius   radius
-     * @param unit     Query.MILES or Query.KILOMETERS
+     * @param unit     Use "mi" for miles or "km" for kilometers
      * @deprecated use {@link #setGeoCode(GeoLocation, double, twitter4j.Query.Unit)} instead
      */
     public void setGeoCode(GeoLocation location, double radius
@@ -372,7 +372,22 @@ public final class Query implements java.io.Serializable {
      * @param radius   radius
      * @param unit     Query.MILES or Query.KILOMETERS
      * @return the instance
+     */
+    public Query geoCode(GeoLocation location, double radius
+            , Unit unit) {
+        setGeoCode(location, radius, unit);
+        return this;
+    }
+
+    /**
+     * returns tweets by users located within a given radius of the given latitude/longitude, where the user's location is taken from their Twitter profile
+     *
+     * @param location geo location
+     * @param radius   radius
+     * @param unit     Use "mi" for miles or "km" for kilometers
+     * @return the instance
      * @since Twitter4J 2.1.0
+     * @deprecated use {@link #geoCode(GeoLocation, double, twitter4j.Query.Unit)} instead
      */
     public Query geoCode(GeoLocation location, double radius
             , String unit) {


### PR DESCRIPTION
Query class was missing the geoCode method with the new signature with Unit and the old geoCode and setGeoCode were referencing to use the Unit parameter instead of String.
Added deprecation to old geoCode method with String parameter.
