### PR TITLE
Video upload fix

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/LimitedFileInputStream.java
+++ b/twitter4j-core/src/main/java/twitter4j/LimitedFileInputStream.java
@@ -1,0 +1,107 @@
+package twitter4j;
+
+import java.io.*;
+
+/**
+ * A {@link java.io.FileInputStream} that limits input to a given number of bytes
+ *
+ * Created by jrbuckeridge on 7/5/16.
+ */
+public class LimitedFileInputStream extends FileInputStream {
+
+    /**
+     * The initial skip to read from file
+     */
+    protected final long skip;
+
+    /**
+     * Currently skipped bytes
+     */
+    private long currentSkipped = 0;
+
+    /**
+     * Maximum number of bytes to read from file
+     */
+    protected final long max;
+
+    /**
+     * Current count of bytes read
+     */
+    protected int count = 0;
+
+    public LimitedFileInputStream(String name, long skip, long max) throws FileNotFoundException {
+        super(name);
+        this.skip = skip;
+        this.max = max;
+    }
+
+    public LimitedFileInputStream(File file, long skip, long max) throws FileNotFoundException {
+        super(file);
+        this.skip = skip;
+        this.max = max;
+    }
+
+    public LimitedFileInputStream(FileDescriptor fdObj, long skip, long max) {
+        super(fdObj);
+        this.skip = skip;
+        this.max = max;
+    }
+
+    public long getSkip() {
+        return skip;
+    }
+
+    public long getMax() {
+        return max;
+    }
+
+    /**
+     * Skips the initial bytes if necessary
+     */
+    private void doInitialSkip() throws IOException {
+        while (currentSkipped < skip) {
+            currentSkipped += skip(skip - currentSkipped);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        doInitialSkip();
+        if (count >= max) {
+            return -1;
+        }
+
+        int read = super.read();
+        count++;
+        return read;
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        doInitialSkip();
+        if (count >= max) {
+            return -1;
+        }
+
+        return read(b, 0, b.length);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        doInitialSkip();
+        if (count >= max) {
+            return -1;
+        }
+
+        long pending = max - count;
+        int read = super.read(b, off, b.length < pending ? b.length : (int) pending);
+        count += read;
+        return read;
+    }
+
+    @Override
+    public int available() throws IOException {
+        int available = super.available();
+        return available > max - count ? (int) (max - count) : available;
+    }
+}

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -271,6 +271,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
             int bytesRead;
             for (int i = 0; i < count; i++) {
                 videos[i] = File.createTempFile("video-chunk-", ".part" + i);
+                videos[i].deleteOnExit();
                 final OutputStream outputStream = new FileOutputStream(videos[i]);
                 for (int t = 0; t < totalReads; t++) {
                     bytesRead = inputStream.read(buffer, 0, buffer.length);

--- a/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
@@ -181,4 +181,21 @@ public interface TweetsResources {
      * @since Twitter4J 4.0.3
      */
     UploadedMedia uploadMedia(String fileName, InputStream media) throws TwitterException;
+    
+    /**
+     * Uploads media using chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}. 
+     * This should be used for videos.
+     * <br>This method calls https://api.twitter.com/1.1/media/upload.json
+     *
+     * @param fileName media file name
+     * @param media media body as stream
+     * @param size of the media in bytes
+     * @return upload result
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/rest/public/uploading-media#chunkedupload">Uploading Media | Twitter Developers</a>
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/post/statuses/update">POST statuses/update | Twitter Developers</a>
+     * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
+     * @since Twitter4J 4.0.3
+     */
+    UploadedMedia uploadMediaChunked(String fileName, InputStream media, long size) throws TwitterException;
 }

--- a/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
@@ -19,6 +19,7 @@ package twitter4j.api;
 import twitter4j.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -181,15 +182,13 @@ public interface TweetsResources {
      * @since Twitter4J 4.0.3
      */
     UploadedMedia uploadMedia(String fileName, InputStream media) throws TwitterException;
-    
+
     /**
      * Uploads media using chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}. 
      * This should be used for videos.
      * <br>This method calls https://api.twitter.com/1.1/media/upload.json
      *
-     * @param fileName media file name
-     * @param media media body as stream
-     * @param size of the media in bytes
+     * @param video video file to upload
      * @return upload result
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/rest/public/uploading-media#chunkedupload">Uploading Media | Twitter Developers</a>
@@ -197,5 +196,5 @@ public interface TweetsResources {
      * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
      * @since Twitter4J 4.0.3
      */
-    UploadedMedia uploadMediaChunked(String fileName, InputStream media, long size) throws TwitterException;
+    UploadedMedia uploadMediaChunked(File video) throws TwitterException, IOException;
 }

--- a/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
@@ -196,5 +196,5 @@ public interface TweetsResources {
      * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
      * @since Twitter4J 4.0.3
      */
-    UploadedMedia uploadMediaChunked(File video) throws TwitterException, IOException;
+    UploadedMedia uploadVideo(File video) throws TwitterException, IOException;
 }

--- a/twitter4j-core/src/test/java/twitter4j/LimitedFileInputStreamTest.java
+++ b/twitter4j-core/src/test/java/twitter4j/LimitedFileInputStreamTest.java
@@ -1,0 +1,62 @@
+package twitter4j;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Test for the {@link LimitedFileInputStream}
+ * Created by jrbuckeridge on 7/5/16.
+ */
+public class LimitedFileInputStreamTest {
+
+    private static final byte[] FILE_CONTENT = "0123456789abcdefghij54321qwerty".getBytes();
+
+    private static class SkipMaxCombination {
+        final int skip;
+        final int max;
+
+        public SkipMaxCombination(int skip, int max) {
+            this.skip = skip;
+            this.max = max;
+        }
+    }
+
+    @Test
+    public void testRead() {
+
+        List<SkipMaxCombination> combinations = new ArrayList<SkipMaxCombination>();
+        combinations.add(new SkipMaxCombination(10, 5));
+        combinations.add(new SkipMaxCombination(20, 5));
+        combinations.add(new SkipMaxCombination(20, 10));
+        combinations.add(new SkipMaxCombination(0, 15));
+        combinations.add(new SkipMaxCombination(3, 12));
+
+        for (SkipMaxCombination combination : combinations) {
+            try {
+                LimitedFileInputStream inputStream =
+                        new LimitedFileInputStream(getClass().getResource("/limited-input.test").getFile(),
+                                combination.skip,
+                                combination.max);
+
+                byte[] bytes = new byte[combination.max];
+                // could improve the test by relying on read bytes, but there's no need because the numbers are really small
+                int read = inputStream.read(bytes);
+                assertArrayEquals(getArray(combination.skip, combination.max), bytes);
+                System.out.println("Read: " + new String(bytes));
+
+            } catch (IOException e) {
+                e.printStackTrace();
+                fail(e.getMessage());
+            }
+        }
+    }
+
+    private byte[] getArray(int skip, int max) {
+        return Arrays.copyOfRange(FILE_CONTENT, skip, skip + max);
+    }
+}

--- a/twitter4j-core/src/test/resources/limited-input.test
+++ b/twitter4j-core/src/test/resources/limited-input.test
@@ -1,0 +1,1 @@
+0123456789abcdefghij54321qwerty


### PR DESCRIPTION
Fixes the chunked video upload providing support for files longer than 5MB.
There are also some minor changes to prevent unnecessary array creation during calls to varargs methods.

Note: The work is done on top of @dk8996 changes but he hasn't been active lately.