### PR TITLE
Remove seemingly unnecessary double work

### DIFF
--- a/twitter4j-core/src/internal-json/java/twitter4j/StatusJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/StatusJSONImpl.java
@@ -194,13 +194,6 @@ import static twitter4j.ParseUtil.getDate;
                 quotedStatusId = ParseUtil.getLong("quoted_status_id", json);
             }
 
-            if (!json.isNull("quoted_status")) {
-                quotedStatus = new StatusJSONImpl(json.getJSONObject("quoted_status"));
-            }
-            if (!json.isNull("quoted_status_id")) {
-                quotedStatusId = ParseUtil.getLong("quoted_status_id", json);
-            }
-
             userMentionEntities = userMentionEntities == null ? new UserMentionEntity[0] : userMentionEntities;
             urlEntities = urlEntities == null ? new URLEntity[0] : urlEntities;
             hashtagEntities = hashtagEntities == null ? new HashtagEntity[0] : hashtagEntities;


### PR DESCRIPTION
The two identical chunks of code originate from separate commits. Maybe some kind of merge hazard has included both?

Surely doing the same work again won't break anything but it looks wasteful.