### PR TITLE
Resolves TFJ-886 - Adds tweetVolume field to Trend

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,7 @@ Tomoaki Iwasaki <multicolorworld.shinku at gmail.com> @MulticolorWorld
 Tomoaki Takezoe <sumito3478 at gmail.com> @sumito3478
 Tomohisa Igarashi <tm.igarashi at gmail.com>
 Tyler MacLeod
+Venil Noronha <venil.noronha at gmail.com> @venilnoronha
 Will Glozer <will at glozer.net> @ar3te
 William Morgan <william at twitter.com> @wm
 William O'Hanley <william at wohanley.com> @wohanley

--- a/twitter4j-core/src/internal-json/java/twitter4j/TrendJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/TrendJSONImpl.java
@@ -27,11 +27,13 @@ package twitter4j;
     private final String name;
     private String url = null;
     private String query = null;
+    private long tweetVolume = -1L;
 
     /*package*/ TrendJSONImpl(JSONObject json, boolean storeJSON) {
         this.name = ParseUtil.getRawString("name", json);
         this.url = ParseUtil.getRawString("url", json);
         this.query = ParseUtil.getRawString("query", json);
+        this.tweetVolume = ParseUtil.getLong("tweet_volume", json);
         if (storeJSON) {
             TwitterObjectFactory.registerJSONObject(this, json);
         }
@@ -57,6 +59,11 @@ package twitter4j;
     }
 
     @Override
+    public long getTweetVolume() {
+        return tweetVolume;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Trend)) return false;
@@ -68,6 +75,8 @@ package twitter4j;
             return false;
         if (url != null ? !url.equals(trend.getURL()) : trend.getURL() != null)
             return false;
+        if (tweetVolume != trend.getTweetVolume())
+            return false;
 
         return true;
     }
@@ -77,6 +86,7 @@ package twitter4j;
         int result = name.hashCode();
         result = 31 * result + (url != null ? url.hashCode() : 0);
         result = 31 * result + (query != null ? query.hashCode() : 0);
+        result = 31 * result + (int) (tweetVolume ^ (tweetVolume >>> 32));
         return result;
     }
 
@@ -86,6 +96,7 @@ package twitter4j;
                 "name='" + name + '\'' +
                 ", url='" + url + '\'' +
                 ", query='" + query + '\'' +
+                ", tweetVolume='" + tweetVolume + '\'' +
                 '}';
     }
 }

--- a/twitter4j-core/src/main/java/twitter4j/Trend.java
+++ b/twitter4j-core/src/main/java/twitter4j/Trend.java
@@ -30,4 +30,6 @@ public interface Trend extends java.io.Serializable {
 
     String getQuery();
 
+    long getTweetVolume();
+
 }


### PR DESCRIPTION
Adds support for the `tweet_volume` field of `/trends/place` API response. Refer to the [Twitter API Documentation](https://dev.twitter.com/rest/reference/get/trends/place) for more information.
