### PR TITLE
Allow to create GeoQuery only with string

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/GeoQuery.java
+++ b/twitter4j-core/src/main/java/twitter4j/GeoQuery.java
@@ -51,6 +51,15 @@ public final class GeoQuery implements java.io.Serializable {
         this.ip = ip;
     }
 
+    /**
+     * Creates a GeoQuery with the specified query
+     *
+     * @param query Query string
+     */
+    public GeoQuery(String query) {
+        this.query = query;
+    }
+
     public GeoLocation getLocation() {
         return location;
     }


### PR DESCRIPTION
Twitter's GET geo/search API allows to pass query string only. https://dev.twitter.com/rest/reference/get/geo/search

However in Twitter4j, there is no way to create GeoQuery instance with query string. (currently, we must provide lat/long, or ip to create a GeoQuery instance).