### PR TITLE
Added support for chunked upload (again)

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -40,9 +40,14 @@ import static twitter4j.HttpParameter.getParameterArray;
  */
 class TwitterImpl extends TwitterBaseImpl implements Twitter {
     private static final long serialVersionUID = 9170943084096085770L;
+    private static final Logger logger = Logger.getLogger(TwitterBaseImpl.class);
+    
     private final String IMPLICIT_PARAMS_STR;
     private final HttpParameter[] IMPLICIT_PARAMS;
     private final HttpParameter INCLUDE_MY_RETWEET;
+
+	private final int chunkedUploadFinalizeTimeout;
+	private final int chunkedUploadSegmentSize;
 
     private static final ConcurrentHashMap<Configuration, HttpParameter[]> implicitParamsMap = new ConcurrentHashMap<Configuration, HttpParameter[]>();
     private static final ConcurrentHashMap<Configuration, String> implicitParamsStrMap = new ConcurrentHashMap<Configuration, String>();
@@ -97,6 +102,8 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
             this.IMPLICIT_PARAMS = implicitParams;
             this.IMPLICIT_PARAMS_STR = implicitParamsStr;
         }
+        this.chunkedUploadFinalizeTimeout = conf.getChunkedUploadFinalizeTimeout();
+        this.chunkedUploadSegmentSize = conf.getChunkedUploadSegmentSize();
     }
 
     /* Timelines Resources */
@@ -257,6 +264,114 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
                 , new HttpParameter("media", fileName, image)).asJSONObject());
     }
 
+
+    @Override
+    public UploadedMedia uploadMediaChunked(File mediaFile) throws TwitterException {
+        checkFileValidity(mediaFile);
+        try {
+            return uploadMediaChunked(mediaFile.getName(), new FileInputStream(mediaFile), mediaFile.length());
+        } catch (IOException e) {
+            throw new TwitterException(e);
+        }
+    }
+
+
+	@Override
+	public UploadedMedia uploadMediaChunked(String fileName, InputStream media, long mediaLength) throws TwitterException {
+		try {
+			UploadedMedia uploadedMedia = uploadMediaChunkedInit(mediaLength);
+			BufferedInputStream buffered = new BufferedInputStream(media);
+
+			byte[] segmentData = new byte[chunkedUploadSegmentSize];
+			int totalRead = 0;
+
+			for (int bytesRead = 0, segmentIndex = 0; (bytesRead = buffered.read(segmentData)) > 0; ++segmentIndex) {
+				totalRead += bytesRead;
+				logger.debug("Chunked append, segment index:" + segmentIndex + " bytes:" + totalRead + "/" + mediaLength);
+				uploadMediaChunkedAppend(fileName, new ByteArrayInputStream(segmentData, 0, bytesRead), segmentIndex, uploadedMedia.getMediaId());
+			}
+			return uploadMediaChunkedFinalize(uploadedMedia.getMediaId());
+		} catch (Exception e) {
+			 throw new TwitterException(e);
+		}
+	}
+    
+    private UploadedMedia uploadMediaChunkedInit(long size) throws TwitterException {
+		return new UploadedMedia(
+		    post(conf.getUploadBaseURL() + "media/upload.json",
+            new HttpParameter[] {
+                new HttpParameter("command", "INIT"),
+                new HttpParameter("media_type", "video/mp4"),
+                new HttpParameter("media_category", "tweet_video"),
+                new HttpParameter("total_bytes", size)
+            }
+        ).asJSONObject());
+	}
+
+    private void uploadMediaChunkedAppend(String fileName, InputStream segmentData, int segmentIndex, long mediaId) throws TwitterException {
+		post(conf.getUploadBaseURL() + "media/upload.json",
+		    new HttpParameter[] {
+                new HttpParameter("command", "APPEND"),
+                new HttpParameter("media_id", mediaId),
+                new HttpParameter("media", fileName, segmentData),
+                new HttpParameter("segment_index", segmentIndex)
+            }
+        );
+	}
+
+	private UploadedMedia uploadMediaChunkedFinalize(long mediaId) throws TwitterException {
+        int totalWaitSec = 0;
+		UploadedMedia uploadedMedia = uploadMediaChunkedFinalize0(mediaId);
+		while (true) {
+			String state = uploadedMedia.getProcessingState();
+			if (state.equals("failed")) {
+				throw new TwitterException("Failed to finalize the chunked upload.");
+			}
+			if (state.equals("pending") || state.equals("in_progress")) {
+				int waitSec = uploadedMedia.getProcessingCheckAfterSecs();
+				if (waitSec <= 0) {
+                    throw new TwitterException("Failed to finalize the chunked upload, invalid check_after_secs value "+waitSec);
+                }
+                totalWaitSec += waitSec;
+                if (totalWaitSec > chunkedUploadFinalizeTimeout) {
+                    throw new TwitterException("Failed to finalize the chunked upload, timed out after " + totalWaitSec + " seconds");
+                }
+				logger.debug("Chunked finalize, wait for:" + waitSec + " sec");
+				try {
+					Thread.sleep(waitSec * 1000);
+				} catch (InterruptedException e) {
+					throw new TwitterException("Failed to finalize the chunked upload.", e);
+				}
+			}
+			if (state.equals("succeeded")) {
+				return uploadedMedia;
+			}
+			uploadedMedia = uploadMediaChunkedStatus(mediaId);
+		}
+	}
+	
+	private UploadedMedia uploadMediaChunkedFinalize0(long mediaId) throws TwitterException {
+		JSONObject json = post(
+            conf.getUploadBaseURL() + "media/upload.json",
+            new HttpParameter[] {
+                new HttpParameter("command", "FINALIZE"),
+                new HttpParameter("media_id", mediaId) }
+        ).asJSONObject();
+		logger.debug("Finalize response:" + json);
+		return new UploadedMedia(json);
+	}
+	
+	private UploadedMedia uploadMediaChunkedStatus(long mediaId) throws TwitterException {
+		JSONObject json = get(
+				conf.getUploadBaseURL() + "media/upload.json",
+				new HttpParameter[] {
+						new HttpParameter("command", "STATUS"),
+						new HttpParameter("media_id", mediaId) })
+				.asJSONObject();
+		logger.debug("Status response:" + json);
+		return new UploadedMedia(json);
+	}
+    
     /* Search Resources */
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/UploadedMedia.java
+++ b/twitter4j-core/src/main/java/twitter4j/UploadedMedia.java
@@ -30,6 +30,8 @@ public final class UploadedMedia implements java.io.Serializable {
     private String imageType;
     private long mediaId;
     private long size;
+    private String processingState;
+    private int processingCheckAfterSecs;
 
     /*package*/ UploadedMedia(JSONObject json) throws TwitterException {
         init(json);
@@ -55,6 +57,14 @@ public final class UploadedMedia implements java.io.Serializable {
         return size;
     }
 
+    public String getProcessingState() {
+    	return processingState;
+    }
+    
+    public int getProcessingCheckAfterSecs() {
+    	return processingCheckAfterSecs;
+    }
+
     private void init(JSONObject json) throws TwitterException {
         mediaId = ParseUtil.getLong("media_id", json);
         size = ParseUtil.getLong("size", json);
@@ -65,6 +75,13 @@ public final class UploadedMedia implements java.io.Serializable {
                 imageHeight = ParseUtil.getInt("h", image);
                 imageType = ParseUtil.getUnescapedString("image_type", image);
             }
+            
+            if (!json.isNull("processing_info")) {
+            	JSONObject processingInfo = json.getJSONObject("processing_info");
+            	processingState = ParseUtil.getUnescapedString("state", processingInfo);
+            	processingCheckAfterSecs = ParseUtil.getInt("check_after_secs", processingInfo);
+            }
+            
         } catch (JSONException jsone) {
             throw new TwitterException(jsone);
         }

--- a/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
@@ -159,7 +159,7 @@ public interface TweetsResources {
      * Uploads media image to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}
      * <br>This method calls https://api.twitter.com/1.1/media/upload.json
      *
-     * @param mediaFile the latest status to be updated.
+     * @param mediaFile media file
      * @return upload result
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/post/statuses/update">POST statuses/update | Twitter Developers</a>
@@ -181,4 +181,36 @@ public interface TweetsResources {
      * @since Twitter4J 4.0.3
      */
     UploadedMedia uploadMedia(String fileName, InputStream media) throws TwitterException;
+    
+    /**
+     * Uploads media using chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}. 
+     * This should be used for videos and animated GIFs.
+     * <br>This method calls https://api.twitter.com/1.1/media/upload.json
+     *
+     * @param mediaFile media file
+     * @return upload result
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/rest/public/uploading-media#chunkedupload">Uploading Media | Twitter Developers</a>
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/post/statuses/update">POST statuses/update | Twitter Developers</a>
+     * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
+     * @since Twitter4J 4.0.6
+     */
+    UploadedMedia uploadMediaChunked(File mediaFile) throws TwitterException;
+
+    /**
+     * Uploads media using chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
+     * This should be used for videos and animated GIFs.
+     * <br>This method calls https://api.twitter.com/1.1/media/upload.json
+     *
+     * @param fileName media file name
+     * @param media media body as stream
+     * @param mediaLength total media length
+     * @return upload result
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/rest/public/uploading-media#chunkedupload">Uploading Media | Twitter Developers</a>
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/post/statuses/update">POST statuses/update | Twitter Developers</a>
+     * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
+     * @since Twitter4J 4.0.6
+     */
+    UploadedMedia uploadMediaChunked(String fileName, InputStream media, long mediaLength) throws TwitterException;
 }

--- a/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
@@ -193,8 +193,7 @@ public interface TweetsResources {
      * @see <a href="https://dev.twitter.com/rest/public/uploading-media#chunkedupload">Uploading Media | Twitter Developers</a>
      * @see <a href="https://dev.twitter.com/docs/api/1.1/post/statuses/update">POST statuses/update | Twitter Developers</a>
      * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
-     * @since Twitter4J 4.0.6
-     */
+    */
     UploadedMedia uploadMediaChunked(File mediaFile) throws TwitterException;
 
     /**
@@ -210,7 +209,6 @@ public interface TweetsResources {
      * @see <a href="https://dev.twitter.com/rest/public/uploading-media#chunkedupload">Uploading Media | Twitter Developers</a>
      * @see <a href="https://dev.twitter.com/docs/api/1.1/post/statuses/update">POST statuses/update | Twitter Developers</a>
      * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
-     * @since Twitter4J 4.0.6
-     */
+    */
     UploadedMedia uploadMediaChunked(String fileName, InputStream media, long mediaLength) throws TwitterException;
 }

--- a/twitter4j-core/src/main/java/twitter4j/conf/Configuration.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/Configuration.java
@@ -124,4 +124,14 @@ public interface Configuration extends AuthorizationConfiguration, java.io.Seria
     boolean isIncludeEmailEnabled();
 
     String getStreamThreadName();
+
+    /**
+     * Timeout (in seconds) for chunked upload finalization.
+     */
+    int getChunkedUploadFinalizeTimeout();
+
+    /**
+     * Size of segments (in bytes) when performing a chunked upload
+     */
+    int getChunkedUploadSegmentSize();
 }

--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
@@ -93,6 +93,9 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
 
     private String streamThreadName = "";
 
+    private int chunkedUploadFinalizeTimeout = 30;          // When doing a chunked upload, bail out after 30 seconds by default
+    private int chunkedUploadSegmentSize = 1 * 1024 * 1024; // Chunked upload segment size defaults to 1MB
+
     protected ConfigurationBase() {
         httpConf = new MyHttpClientConfiguration(null // proxy host
                 , null // proxy user
@@ -742,6 +745,24 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
         return this.streamThreadName;
     }
 
+    @Override
+    public int getChunkedUploadFinalizeTimeout() {
+        return this.chunkedUploadFinalizeTimeout;
+    }
+
+    protected final void setChunkedUploadFinalizeTimeout(int value) {
+        this.chunkedUploadFinalizeTimeout = value;
+    }
+
+    @Override
+    public int getChunkedUploadSegmentSize() {
+        return this.chunkedUploadSegmentSize;
+    }
+
+    protected final void setChunkedUploadSegmentSize(int value) {
+        this.chunkedUploadSegmentSize = value;
+    }
+
     protected final void setStreamThreadName(String streamThreadName) {
         this.streamThreadName = streamThreadName;
     }
@@ -835,6 +856,8 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
             return false;
         if (mediaProviderParameters != null ? !mediaProviderParameters.equals(that.mediaProviderParameters) : that.mediaProviderParameters != null)
             return false;
+        if (chunkedUploadFinalizeTimeout != that.chunkedUploadFinalizeTimeout) return false;
+        if (chunkedUploadSegmentSize != that.chunkedUploadSegmentSize) return false;
         return streamThreadName != null ? streamThreadName.equals(that.streamThreadName) : that.streamThreadName == null;
 
     }
@@ -887,6 +910,8 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
         result = 31 * result + (mediaProviderParameters != null ? mediaProviderParameters.hashCode() : 0);
         result = 31 * result + (daemonEnabled ? 1 : 0);
         result = 31 * result + (streamThreadName != null ? streamThreadName.hashCode() : 0);
+        result = 31 * result + chunkedUploadFinalizeTimeout;
+        result = 31 * result + chunkedUploadSegmentSize;
         return result;
     }
 
@@ -926,7 +951,6 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 ", includeEntitiesEnabled=" + includeEntitiesEnabled +
                 ", trimUserEnabled=" + trimUserEnabled +
                 ", includeExtAltTextEnabled=" + includeExtAltTextEnabled +
-                ", tweetModeExtended=" + tweetModeExtended +
                 ", includeEmailEnabled=" + includeEmailEnabled +
                 ", jsonStoreEnabled=" + jsonStoreEnabled +
                 ", mbeanEnabled=" + mbeanEnabled +
@@ -964,7 +988,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
         }
     }
 
-    // assures equality after deserializedation
+    // assures equality after deserialization
     protected Object readResolve() throws ObjectStreamException {
         return getInstance(this);
     }

--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBuilder.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBuilder.java
@@ -324,6 +324,18 @@ public final class ConfigurationBuilder {
         return this;
     }
 
+    public ConfigurationBuilder setChunkedUploadFinalizeTimeout(int value) {
+        checkNotBuilt();
+        configurationBean.setChunkedUploadFinalizeTimeout(value);
+        return this;
+    }
+
+    public ConfigurationBuilder setChunkedUploadSegmentSize(int value) {
+        checkNotBuilt();
+        configurationBean.setChunkedUploadSegmentSize(value);
+        return this;
+    }
+
     public Configuration build() {
         checkNotBuilt();
         configurationBean.cacheInstance();

--- a/twitter4j-core/src/main/java/twitter4j/conf/PropertyConfiguration.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/PropertyConfiguration.java
@@ -88,6 +88,10 @@ public final class PropertyConfiguration extends ConfigurationBase implements ja
     private static final String MEDIA_PROVIDER = "media.provider";
     private static final String MEDIA_PROVIDER_API_KEY = "media.providerAPIKey";
     private static final String MEDIA_PROVIDER_PARAMETERS = "media.providerParameters";
+
+    private static final String CHUNKED_UPLOAD_FINALIZE_TIMEOUT = "chunkedUpload.finalizeTimeout";
+    private static final String CHUNKED_UPLOAD_SEGMENT_SIZE = "chunkedUpload.segmentSize";
+
     private static final long serialVersionUID = -7262615247923693252L;
 
 
@@ -400,6 +404,12 @@ public final class PropertyConfiguration extends ConfigurationBase implements ja
                 p.setProperty(parameter[0], parameter[1]);
             }
             setMediaProviderParameters(p);
+        }
+        if (notNull(props, prefix, CHUNKED_UPLOAD_FINALIZE_TIMEOUT)) {
+            setChunkedUploadFinalizeTimeout(getIntProperty(props, prefix, CHUNKED_UPLOAD_FINALIZE_TIMEOUT));
+        }
+        if (notNull(props, prefix, CHUNKED_UPLOAD_SEGMENT_SIZE)) {
+            setChunkedUploadSegmentSize(getIntProperty(props, prefix, CHUNKED_UPLOAD_SEGMENT_SIZE));
         }
         cacheInstance();
     }


### PR DESCRIPTION
Heavily based on dk8996's earlier work in PR #255 (never merged), with a few notable changes:
- Does not read the whole media in memory before uploading
- Makes the chunk size configurable
- Changes the (hard-coded) max retries of the FINALIZE call into a (configurable) timeout