### PR TITLE
Auot populate reply metadata parameter added in Statuspdate class 

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/StatusUpdate.java
+++ b/twitter4j-core/src/main/java/twitter4j/StatusUpdate.java
@@ -195,6 +195,8 @@ public final class StatusUpdate implements java.io.Serializable {
 	/*package*/ HttpParameter[] asHttpParameterArray() {
         ArrayList<HttpParameter> params = new ArrayList<HttpParameter>();
         appendParameter("status", status, params);
+        appendParameter("auto_populate_reply_metadata", String.valueOf(autoPopulateReplyMetadata), params);
+
         if (-1 != inReplyToStatusId) {
             appendParameter("in_reply_to_status_id", inReplyToStatusId, params);
         }
@@ -206,9 +208,6 @@ public final class StatusUpdate implements java.io.Serializable {
         appendParameter("place_id", placeId, params);
         if (!displayCoordinates) {
             appendParameter("display_coordinates", "false", params);
-        }
-        if(!autoPopulateReplyMetadata){
-            appendParameter("auto_populate_reply_metadata", "false", params);
         }
         if (null != mediaFile) {
             params.add(new HttpParameter("media[]", mediaFile));

--- a/twitter4j-core/src/main/java/twitter4j/StatusUpdate.java
+++ b/twitter4j-core/src/main/java/twitter4j/StatusUpdate.java
@@ -244,6 +244,7 @@ public final class StatusUpdate implements java.io.Serializable {
 
         StatusUpdate that = (StatusUpdate) o;
 
+        if (autoPopulateReplyMetadata != that.autoPopulateReplyMetadata) return false;
         if (displayCoordinates != that.displayCoordinates) return false;
         if (inReplyToStatusId != that.inReplyToStatusId) return false;
         if (possiblySensitive != that.possiblySensitive) return false;
@@ -270,6 +271,8 @@ public final class StatusUpdate implements java.io.Serializable {
         result = 31 * result + (mediaBody != null ? mediaBody.hashCode() : 0);
         result = 31 * result + (mediaFile != null ? mediaFile.hashCode() : 0);
         result = 31 * result + (mediaIds != null ? StringUtil.join(mediaIds).hashCode() : 0);
+        result = 31 * result + (autoPopulateReplyMetadata ? 1 : 0);
+
         return result;
     }
 
@@ -286,6 +289,7 @@ public final class StatusUpdate implements java.io.Serializable {
             ", mediaBody=" + mediaBody +
             ", mediaFile=" + mediaFile +
             ", mediaIds=" + mediaIds +
+            ",autoPopulateReplyMetadata="+autoPopulateReplyMetadata+
             '}';
     }
 }

--- a/twitter4j-core/src/main/java/twitter4j/StatusUpdate.java
+++ b/twitter4j-core/src/main/java/twitter4j/StatusUpdate.java
@@ -39,6 +39,8 @@ public final class StatusUpdate implements java.io.Serializable {
     private transient InputStream mediaBody;
     private File mediaFile;
     private long[] mediaIds;
+    private boolean autoPopulateReplyMetadata = true ;
+
 
     public StatusUpdate(String status) {
         this.status = status;
@@ -176,8 +178,21 @@ public final class StatusUpdate implements java.io.Serializable {
     public boolean isPossiblySensitive() {
         return possiblySensitive;
     }
+    
+    
+    /**
+     * @return auto populate reply metadata
+     * @since Twitter4J 4.0.6
+     */
+   public boolean isAutoPopulateReplyMetadata() {
+		return autoPopulateReplyMetadata;
+	}
 
-    /*package*/ HttpParameter[] asHttpParameterArray() {
+	public void setAutoPopulateReplyMetadata(boolean autoPopulateReplyMetadata) {
+		this.autoPopulateReplyMetadata = autoPopulateReplyMetadata;
+	}
+
+	/*package*/ HttpParameter[] asHttpParameterArray() {
         ArrayList<HttpParameter> params = new ArrayList<HttpParameter>();
         appendParameter("status", status, params);
         if (-1 != inReplyToStatusId) {
@@ -191,6 +206,9 @@ public final class StatusUpdate implements java.io.Serializable {
         appendParameter("place_id", placeId, params);
         if (!displayCoordinates) {
             appendParameter("display_coordinates", "false", params);
+        }
+        if(!autoPopulateReplyMetadata){
+            appendParameter("auto_populate_reply_metadata", "false", params);
         }
         if (null != mediaFile) {
             params.add(new HttpParameter("media[]", mediaFile));


### PR DESCRIPTION
Added auto_populate_reply_metadata parameter added in StatusUpdate class  to handle auto populating the handle while reply is made by the user.This fix will handle 140 characters limit excluding the handle.