### PR TITLE
fix: make StreamListener public

### DIFF
--- a/twitter4j-stream/src/main/java/twitter4j/StreamListener.java
+++ b/twitter4j-stream/src/main/java/twitter4j/StreamListener.java
@@ -20,6 +20,6 @@ package twitter4j;
  * @author Yusuke Yamamoto - yusuke at mac.com
  * @since Twitter4J 2.1.8
  */
-interface StreamListener {
+public interface StreamListener {
     void onException(Exception ex);
 }


### PR DESCRIPTION
To fix java.lang.IllegalAccessError on other JVMs [see](https://stackoverflow.com/questions/45781964/how-to-make-kotlin-stop-casting-argument-to-wrong-classinterface)