### PR TITLE
Updated documentation for EntitySupport.java

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/EntitySupport.java
+++ b/twitter4j-core/src/main/java/twitter4j/EntitySupport.java
@@ -37,7 +37,7 @@ public interface EntitySupport {
     URLEntity[] getURLEntities();
 
     /**
-     * Returns an array if hashtag mentioned in the tweet.  This method will an empty array if no hashtags were mentioned in the tweet.
+     * Returns an array if hashtag mentioned in the tweet.  This method will return an empty array if no hashtags were mentioned in the tweet.
      *
      * @return An array of Hashtag mentioned in the tweet.
      * @since Twitter4J 2.1.9


### PR DESCRIPTION
Added the word 'return' to change "This method will an empty" to "This method will return an empty" in the documentation for getHashtagEntities() in EntitySupport.java.