### PR TITLE
add 400x400 size of profile image

### DIFF
--- a/twitter4j-appengine/src/main/java/twitter4j/LazyUser.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/LazyUser.java
@@ -167,6 +167,11 @@ final class LazyUser implements twitter4j.User {
         return getTarget().getOriginalProfileImageURL();
     }
 
+    @Override
+    public String get400x400ProfileImageURL() {
+        return getTarget().get400x400ProfileImageURL();
+    }
+
     /**
      * Returns the profile image url of the user, served over SSL
      *
@@ -189,6 +194,11 @@ final class LazyUser implements twitter4j.User {
     @Override
     public String getOriginalProfileImageURLHttps() {
         return getTarget().getOriginalProfileImageURLHttps();
+    }
+
+    @Override
+    public String get400x400ProfileImageURLHttps() {
+        return getTarget().get400x400ProfileImageURLHttps();
     }
 
     @Override

--- a/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
@@ -256,6 +256,11 @@ import java.util.Date;
         return toResizedURL(profileImageUrl, "");
     }
 
+    @Override
+    public String get400x400ProfileImageURL() {
+        return toResizedURL(profileImageUrl, "_400x400");
+    }
+
     private String toResizedURL(String originalURL, String sizeSuffix) {
         if (null != originalURL) {
             int index = originalURL.lastIndexOf("_");
@@ -288,6 +293,11 @@ import java.util.Date;
     @Override
     public String getOriginalProfileImageURLHttps() {
         return toResizedURL(profileImageUrlHttps, "");
+    }
+
+    @Override
+    public String get400x400ProfileImageURLHttps() {
+        return toResizedURL(profileImageUrlHttps, "_400x400");
     }
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/User.java
+++ b/twitter4j-core/src/main/java/twitter4j/User.java
@@ -87,6 +87,8 @@ public interface User extends Comparable<User>, TwitterResponse, java.io.Seriali
 
     String getOriginalProfileImageURL();
 
+    String get400x400ProfileImageURL();
+
     String getProfileImageURLHttps();
 
     String getBiggerProfileImageURLHttps();
@@ -94,6 +96,8 @@ public interface User extends Comparable<User>, TwitterResponse, java.io.Seriali
     String getMiniProfileImageURLHttps();
 
     String getOriginalProfileImageURLHttps();
+
+    String get400x400ProfileImageURLHttps();
 
     /**
      * Tests if the user has not uploaded their own avatar


### PR DESCRIPTION
It seems that "_400x400" has been used as the URL of the profile image so add it.

----

プロフィール画像の URL として _400x400 が使われるようになったようなのでそれを取得できるようにしました。