### PR TITLE
AlternativeHttpClientImplのインスタンスからOkHttpClientを取得できるようにgetterの追加

### DIFF
--- a/twitter4j-http2-support/src/main/java/twitter4j/AlternativeHttpClientImpl.java
+++ b/twitter4j-http2-support/src/main/java/twitter4j/AlternativeHttpClientImpl.java
@@ -297,6 +297,7 @@ public class AlternativeHttpClientImpl extends HttpClientBase implements HttpRes
     }
 
     public OkHttpClient getOkHttpClient() {
+        prepareOkHttpClient();
         return okHttpClient;
     }
 }

--- a/twitter4j-http2-support/src/main/java/twitter4j/AlternativeHttpClientImpl.java
+++ b/twitter4j-http2-support/src/main/java/twitter4j/AlternativeHttpClientImpl.java
@@ -296,4 +296,7 @@ public class AlternativeHttpClientImpl extends HttpClientBase implements HttpRes
         return lastRequestProtocol;
     }
 
+    public OkHttpClient getOkHttpClient() {
+        return okHttpClient;
+    }
 }


### PR DESCRIPTION
AlternativeHttpClientImpl#getOkHttpClient()を追加しました

twitter4j-http2-supportを使ってる時に、TwitterからOkHttpClientを取るときに、以下のコードでリフレクション無しでOkHttpClientインスタンスを取れるようになります

```Java
Twitter twitter = new TwitterFactory().getInstance();
HttpClient httpClient = HttpClientFactory.getInstance(twitter.getConfiguration().getHttpClientConfiguration());
if (httpClient instanceof AlternativeHttpClientImpl) {
    client = ((AlternativeHttpClientImpl) httpClient).getOkHttpClient();
}
```