### PR TITLE
care empty string of profile image url

### DIFF
--- a/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
@@ -257,7 +257,7 @@ import java.util.Date;
     }
 
     private String toResizedURL(String originalURL, String sizeSuffix) {
-        if (null != originalURL) {
+        if (null != originalURL && originalURL.length() >= 1) {
             int index = originalURL.lastIndexOf("_");
             int suffixIndex = originalURL.lastIndexOf(".");
             int slashIndex = originalURL.lastIndexOf("/");


### PR DESCRIPTION
fix ```StringIndexOutOfBoundsException: length=0; regionStart=0; regionLength=-1``` when the profile image url is empty (not null).