### PR TITLE
Added httpProxySocks boolean property to HttpClientConfiguration

### DIFF
--- a/twitter4j-core/src/internal-http/java/twitter4j/HttpClientConfiguration.java
+++ b/twitter4j-core/src/internal-http/java/twitter4j/HttpClientConfiguration.java
@@ -29,6 +29,8 @@ public interface HttpClientConfiguration {
 
     String getHttpProxyPassword();
 
+    boolean isHttpProxySocks();
+
     int getHttpConnectionTimeout();
 
     int getHttpReadTimeout();

--- a/twitter4j-core/src/internal-http/java/twitter4j/HttpClientImpl.java
+++ b/twitter4j-core/src/internal-http/java/twitter4j/HttpClientImpl.java
@@ -241,8 +241,8 @@ class HttpClientImpl extends HttpClientBase implements HttpResponseCode, java.io
                     }
                 });
             }
-            final Proxy proxy = new Proxy(Proxy.Type.HTTP, InetSocketAddress
-                    .createUnresolved(CONF.getHttpProxyHost(), CONF.getHttpProxyPort()));
+            final Proxy proxy = new Proxy(CONF.isHttpProxySocks() ? Proxy.Type.SOCKS : Proxy.Type.HTTP,
+                    InetSocketAddress.createUnresolved(CONF.getHttpProxyHost(), CONF.getHttpProxyPort()));
             if (logger.isDebugEnabled()) {
                 logger.debug("Opening proxied connection(" + CONF.getHttpProxyHost() + ":" + CONF.getHttpProxyPort() + ")");
             }

--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
@@ -22,6 +22,7 @@ import twitter4j.Logger;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -98,6 +99,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 , null // proxy user
                 , null // proxy password
                 , -1 // proxy port
+                , false // proxy socks
                 , 20000 // connection timeout
                 , 120000 // read timeout
                 , false // pretty debug
@@ -110,17 +112,19 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
         private String httpProxyHost = null;
         private String httpProxyUser = null;
         private String httpProxyPassword = null;
+        private boolean httpProxySocks = false;
         private int httpProxyPort = -1;
         private int httpConnectionTimeout = 20000;
         private int httpReadTimeout = 120000;
         private boolean prettyDebug = false;
         private boolean gzipEnabled = true;
 
-        MyHttpClientConfiguration(String httpProxyHost, String httpProxyUser, String httpProxyPassword, int httpProxyPort, int httpConnectionTimeout, int httpReadTimeout, boolean prettyDebug, boolean gzipEnabled) {
+        MyHttpClientConfiguration(String httpProxyHost, String httpProxyUser, String httpProxyPassword, int httpProxyPort, boolean httpProxySocks, int httpConnectionTimeout, int httpReadTimeout, boolean prettyDebug, boolean gzipEnabled) {
             this.httpProxyHost = httpProxyHost;
             this.httpProxyUser = httpProxyUser;
             this.httpProxyPassword = httpProxyPassword;
             this.httpProxyPort = httpProxyPort;
+            this.httpProxySocks = httpProxySocks;
             this.httpConnectionTimeout = httpConnectionTimeout;
             this.httpReadTimeout = httpReadTimeout;
             this.prettyDebug = prettyDebug;
@@ -145,6 +149,11 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
         @Override
         public String getHttpProxyPassword() {
             return httpProxyPassword;
+        }
+
+        @Override
+        public boolean isHttpProxySocks() {
+            return httpProxySocks;
         }
 
         @Override
@@ -185,8 +194,10 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
             MyHttpClientConfiguration that = (MyHttpClientConfiguration) o;
 
             if (gzipEnabled != that.gzipEnabled) return false;
+            if (httpProxySocks != that.httpProxySocks) return false;
             if (httpConnectionTimeout != that.httpConnectionTimeout) return false;
             if (httpProxyPort != that.httpProxyPort) return false;
+            if (httpProxySocks != that.httpProxySocks) return false;
             if (httpReadTimeout != that.httpReadTimeout) return false;
             if (prettyDebug != that.prettyDebug) return false;
             if (httpProxyHost != null ? !httpProxyHost.equals(that.httpProxyHost) : that.httpProxyHost != null)
@@ -205,6 +216,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
             result = 31 * result + (httpProxyUser != null ? httpProxyUser.hashCode() : 0);
             result = 31 * result + (httpProxyPassword != null ? httpProxyPassword.hashCode() : 0);
             result = 31 * result + httpProxyPort;
+            result = 31 * result + (httpProxySocks ? 1 : 0);
             result = 31 * result + httpConnectionTimeout;
             result = 31 * result + httpReadTimeout;
             result = 31 * result + (prettyDebug ? 1 : 0);
@@ -219,6 +231,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                     ", httpProxyUser='" + httpProxyUser + '\'' +
                     ", httpProxyPassword='" + httpProxyPassword + '\'' +
                     ", httpProxyPort=" + httpProxyPort +
+                    ", proxyType=" + (httpProxySocks ? Proxy.Type.SOCKS : Proxy.Type.HTTP) +
                     ", httpConnectionTimeout=" + httpConnectionTimeout +
                     ", httpReadTimeout=" + httpReadTimeout +
                     ", prettyDebug=" + prettyDebug +
@@ -283,10 +296,10 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 , httpConf.getHttpProxyUser()
                 , httpConf.getHttpProxyPassword()
                 , httpConf.getHttpProxyPort()
+                , httpConf.isHttpProxySocks()
                 , httpConf.getHttpConnectionTimeout()
                 , httpConf.getHttpReadTimeout()
-                , prettyDebug
-                , httpConf.isGZIPEnabled()
+                , prettyDebug, httpConf.isGZIPEnabled()
         );
     }
 
@@ -295,10 +308,10 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 , httpConf.getHttpProxyUser()
                 , httpConf.getHttpProxyPassword()
                 , httpConf.getHttpProxyPort()
+                , httpConf.isHttpProxySocks()
                 , httpConf.getHttpConnectionTimeout()
                 , httpConf.getHttpReadTimeout()
-                , httpConf.isPrettyDebugEnabled()
-                , gzipEnabled
+                , httpConf.isPrettyDebugEnabled(), gzipEnabled
         );
     }
 
@@ -309,10 +322,10 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 , httpConf.getHttpProxyUser()
                 , httpConf.getHttpProxyPassword()
                 , httpConf.getHttpProxyPort()
+                , httpConf.isHttpProxySocks()
                 , httpConf.getHttpConnectionTimeout()
                 , httpConf.getHttpReadTimeout()
-                , httpConf.isPrettyDebugEnabled()
-                , httpConf.isGZIPEnabled()
+                , httpConf.isPrettyDebugEnabled(), httpConf.isGZIPEnabled()
         );
     }
 
@@ -321,10 +334,10 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 , proxyUser
                 , httpConf.getHttpProxyPassword()
                 , httpConf.getHttpProxyPort()
+                , httpConf.isHttpProxySocks()
                 , httpConf.getHttpConnectionTimeout()
                 , httpConf.getHttpReadTimeout()
-                , httpConf.isPrettyDebugEnabled()
-                , httpConf.isGZIPEnabled()
+                , httpConf.isPrettyDebugEnabled(), httpConf.isGZIPEnabled()
         );
     }
 
@@ -333,10 +346,10 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 , httpConf.getHttpProxyUser()
                 , proxyPassword
                 , httpConf.getHttpProxyPort()
+                , httpConf.isHttpProxySocks()
                 , httpConf.getHttpConnectionTimeout()
                 , httpConf.getHttpReadTimeout()
-                , httpConf.isPrettyDebugEnabled()
-                , httpConf.isGZIPEnabled()
+                , httpConf.isPrettyDebugEnabled(), httpConf.isGZIPEnabled()
         );
     }
 
@@ -345,10 +358,22 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 , httpConf.getHttpProxyUser()
                 , httpConf.getHttpProxyPassword()
                 , proxyPort
+                , httpConf.isHttpProxySocks()
                 , httpConf.getHttpConnectionTimeout()
                 , httpConf.getHttpReadTimeout()
-                , httpConf.isPrettyDebugEnabled()
-                , httpConf.isGZIPEnabled()
+                , httpConf.isPrettyDebugEnabled(), httpConf.isGZIPEnabled()
+        );
+    }
+
+    protected final void setHttpProxySocks(boolean isSocksProxy) {
+        httpConf = new MyHttpClientConfiguration(httpConf.getHttpProxyHost()
+                , httpConf.getHttpProxyUser()
+                , httpConf.getHttpProxyPassword()
+                , httpConf.getHttpProxyPort()
+                , isSocksProxy
+                , httpConf.getHttpConnectionTimeout()
+                , httpConf.getHttpReadTimeout()
+                , httpConf.isPrettyDebugEnabled(), httpConf.isGZIPEnabled()
         );
     }
 
@@ -357,10 +382,10 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 , httpConf.getHttpProxyUser()
                 , httpConf.getHttpProxyPassword()
                 , httpConf.getHttpProxyPort()
+                , httpConf.isHttpProxySocks()
                 , connectionTimeout
                 , httpConf.getHttpReadTimeout()
-                , httpConf.isPrettyDebugEnabled()
-                , httpConf.isGZIPEnabled()
+                , httpConf.isPrettyDebugEnabled(), httpConf.isGZIPEnabled()
         );
     }
 
@@ -369,10 +394,10 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
                 , httpConf.getHttpProxyUser()
                 , httpConf.getHttpProxyPassword()
                 , httpConf.getHttpProxyPort()
+                , httpConf.isHttpProxySocks()
                 , httpConf.getHttpConnectionTimeout()
                 , readTimeout
-                , httpConf.isPrettyDebugEnabled()
-                , httpConf.isGZIPEnabled()
+                , httpConf.isPrettyDebugEnabled(), httpConf.isGZIPEnabled()
         );
     }
 

--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBuilder.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBuilder.java
@@ -90,6 +90,12 @@ public final class ConfigurationBuilder {
         return this;
     }
 
+    public ConfigurationBuilder setHttpProxySocks(boolean httpProxySocks) {
+        checkNotBuilt();
+        configurationBean.setHttpProxySocks(httpProxySocks);
+        return this;
+    }
+    
     public ConfigurationBuilder setHttpConnectionTimeout(int httpConnectionTimeout) {
         checkNotBuilt();
         configurationBean.setHttpConnectionTimeout(httpConnectionTimeout);

--- a/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
+++ b/twitter4j-stream/src/main/java/twitter4j/TwitterStreamImpl.java
@@ -766,6 +766,11 @@ class StreamingReadTimeoutConfiguration implements HttpClientConfiguration {
     }
 
     @Override
+    public boolean isHttpProxySocks() {
+        return nestedConf.getHttpClientConfiguration().isHttpProxySocks();
+    }
+
+    @Override
     public String getHttpProxyUser() {
         return nestedConf.getHttpClientConfiguration().getHttpProxyUser();
     }


### PR DESCRIPTION
Please support Proxy.Type.SOCKS. Here are the changes required.

`HttpClientConfiguration.httpProxySocks` boolean enables SOCKS proxy mode. If false, uses HTTP
proxy when proxy host and port is properly set.