### PR TITLE
Fix misspelled words in comments

### DIFF
--- a/powered-by-badge/readme.txt
+++ b/powered-by-badge/readme.txt
@@ -1,4 +1,4 @@
-Any service, aplication using Twitter4J can embed the following BSD licensed "powered by" logo. It is suggested to link the badge to "http://twitter4j.org/" without "en/".
+Any service, application using Twitter4J can embed the following BSD licensed "powered by" logo. It is suggested to link the badge to "http://twitter4j.org/" without "en/".
 
 HTML code snippets:
 PNG:

--- a/twitter4j-async/src/test/java/twitter4j/AsyncTwitterTest.java
+++ b/twitter4j-async/src/test/java/twitter4j/AsyncTwitterTest.java
@@ -141,7 +141,7 @@ class AsyncTwitterTest extends TwitterTestBase implements TwitterListener {
         async2.destroyFavorite(status.getId());
         waitForResponse();
         if (te != null && te.getStatusCode() == 404) {
-            // sometimes destorying favorite fails with 404
+            // sometimes destroying favorite fails with 404
         } else {
             assertEquals(status, this.status);
         }

--- a/twitter4j-core/src/main/java/twitter4j/TwitterResponse.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterResponse.java
@@ -17,7 +17,7 @@
 package twitter4j;
 
 /**
- * Super interface of Twitter Response data interfaces which indicates that rate limit status is avaialble.
+ * Super interface of Twitter Response data interfaces which indicates that rate limit status is available.
  *
  * @author Yusuke Yamamoto - yusuke at mac.com
  * @see twitter4j.DirectMessage

--- a/twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java
@@ -38,7 +38,7 @@ public interface FriendsFollowersResources {
      * Returns an array of numeric IDs for every user the authenticating user is following.
      * <br>This method calls https://api.twitter.com/1.1/friends/ids.json
      *
-     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filterd out after connections are queried. <br>
+     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after connections are queried. <br>
      *               To begin paging provide a value of -1 as the cursor. The response from the API will include a previous_cursor and next_cursor to allow paging back and forth.
      * @return an array of numeric IDs for every user the authenticating user is following
      * @throws TwitterException when Twitter service or network is unavailable
@@ -52,7 +52,7 @@ public interface FriendsFollowersResources {
      * <br>This method calls https://api.twitter.com/1.1/friends/ids.json
      *
      * @param userId Specifies the ID of the user for whom to return the friends list.
-     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filterd out after connections are queried. <br>
+     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after connections are queried. <br>
      *               To begin paging provide a value of -1 as the cursor. The response from the API will include a previous_cursor and next_cursor to allow paging back and forth.
      * @return an array of numeric IDs for every user the specified user is following
      * @throws TwitterException when Twitter service or network is unavailable
@@ -66,7 +66,7 @@ public interface FriendsFollowersResources {
      * <br>This method calls http://api.twitter.com/1.1/friends/ids.json
      *
      * @param userId Specifies the ID of the user for whom to return the friends list.
-     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filterd out after connections are queried. <br>
+     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after connections are queried. <br>
      *               To begin paging provide a value of -1 as the cursor. The response from the API will include a previous_cursor and next_cursor to allow paging back and forth.
      * @param count  Specifies the number of IDs attempt retrieval of, up to a maximum of 5,000 per distinct request. The value of count is best thought of as a limit to the number of results to return.<br>
      *               When using the count parameter with this method, it is wise to use a consistent count value across all requests to the same user's collection.<br>
@@ -83,7 +83,7 @@ public interface FriendsFollowersResources {
      * <br>This method calls https://api.twitter.com/1.1/friends/ids.json
      *
      * @param screenName Specifies the screen name of the user for whom to return the friends list.
-     * @param cursor     Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filterd out after connections are queried. <br>
+     * @param cursor     Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after connections are queried. <br>
      *                   To begin paging provide a value of -1 as the cursor. The response from the API will include a previous_cursor and next_cursor to allow paging back and forth.
      * @return an array of numeric IDs for every user the specified user is following
      * @throws TwitterException when Twitter service or network is unavailable
@@ -97,7 +97,7 @@ public interface FriendsFollowersResources {
      * <br>This method calls http://api.twitter.com/1.1/friends/ids.json
      *
      * @param screenName Specifies the screen name of the user for whom to return the friends list.
-     * @param cursor     Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filterd out after connections are queried. <br>
+     * @param cursor     Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after connections are queried. <br>
      *                   To begin paging provide a value of -1 as the cursor. The response from the API will include a previous_cursor and next_cursor to allow paging back and forth.
      * @param count      Specifies the number of IDs attempt retrieval of, up to a maximum of 5,000 per distinct request. The value of count is best thought of as a limit to the number of results to return.<br>
      *                   When using the count parameter with this method, it is wise to use a consistent count value across all requests to the same user's collection.<br>
@@ -113,7 +113,7 @@ public interface FriendsFollowersResources {
      * Returns an array of numeric IDs for every user the specified user is followed by.
      * <br>This method calls https://api.twitter.com/1.1/followers/ids.json
      *
-     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filterd out after connections are queried. <br>
+     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after connections are queried. <br>
      *               To begin paging provide a value of -1 as the cursor. The response from the API will include a previous_cursor and next_cursor to allow paging back and forth.
      * @return The ID or screen_name of the user to retrieve the friends ID list for.
      * @throws TwitterException when Twitter service or network is unavailable
@@ -127,7 +127,7 @@ public interface FriendsFollowersResources {
      * <br>This method calls https://api.twitter.com/1.1/followers/ids.json
      *
      * @param userId Specifies the ID of the user for whom to return the followers list.
-     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filterd out after connections are queried. <br>
+     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after connections are queried. <br>
      *               To begin paging provide a value of -1 as the cursor. The response from the API will include a previous_cursor and next_cursor to allow paging back and forth.
      * @return The ID or screen_name of the user to retrieve the friends ID list for.
      * @throws TwitterException when Twitter service or network is unavailable
@@ -141,7 +141,7 @@ public interface FriendsFollowersResources {
      * <br>This method calls http://api.twitter.com/1.1/followers/ids.json
      *
      * @param userId Specifies the ID of the user for whom to return the followers list.
-     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filterd out after connections are queried. <br>
+     * @param cursor Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after connections are queried. <br>
      *               To begin paging provide a value of -1 as the cursor. The response from the API will include a previous_cursor and next_cursor to allow paging back and forth.
      * @param count  Specifies the number of IDs attempt retrieval of, up to a maximum of 5,000 per distinct request. <br>
      *               The value of count is best thought of as a limit to the number of results to return. <br>
@@ -158,7 +158,7 @@ public interface FriendsFollowersResources {
      * <br>This method calls https://api.twitter.com/1.1/followers/ids.json
      *
      * @param screenName Specifies the screen name of the user for whom to return the followers list.
-     * @param cursor     Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filterd out after connections are queried. <br>
+     * @param cursor     Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after connections are queried. <br>
      *                   To begin paging provide a value of -1 as the cursor. The response from the API will include a previous_cursor and next_cursor to allow paging back and forth.
      * @return The ID or screen_name of the user to retrieve the friends ID list for.
      * @throws TwitterException when Twitter service or network is unavailable
@@ -172,7 +172,7 @@ public interface FriendsFollowersResources {
      * <br>This method calls http://api.twitter.com/1.1/followers/ids.json
      *
      * @param screenName Specifies the screen name of the user for whom to return the followers list.
-     * @param cursor     Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filterd out after connections are queried. <br>
+     * @param cursor     Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after connections are queried. <br>
      *                   To begin paging provide a value of -1 as the cursor. The response from the API will include a previous_cursor and next_cursor to allow paging back and forth.
      * @param count      Specifies the number of IDs attempt retrieval of, up to a maximum of 5,000 per distinct request. <br>
      *                   The value of count is best thought of as a limit to the number of results to return. <br>

--- a/twitter4j-core/src/main/java/twitter4j/api/UsersResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/UsersResources.java
@@ -130,7 +130,7 @@ public interface UsersResources {
         throws TwitterException;
 
     /**
-     * Sets one or more hex values that control the color scheme of the authenticating user's profile page on twitter.com. Each parameter's value must be a valid hexidecimal value, and may be either three or six characters (ex: #fff or #ffffff).
+     * Sets one or more hex values that control the color scheme of the authenticating user's profile page on twitter.com. Each parameter's value must be a valid hexadecimal value, and may be either three or six characters (ex: #fff or #ffffff).
      * <br>This method calls https://api.twitter.com/1.1/account/update_profile_colors.json
      *
      * @param profileBackgroundColor    optional, can be null

--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationFactory.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationFactory.java
@@ -31,7 +31,7 @@ public interface ConfigurationFactory {
      * returns the configuration specified by the path
      *
      * @param configTreePath the path
-     * @return the configuratoin
+     * @return the configuration
      */
     Configuration getInstance(String configTreePath);
 

--- a/twitter4j-http2-support/src/test/java/twitter4j/Http2ClientTest.java
+++ b/twitter4j-http2-support/src/test/java/twitter4j/Http2ClientTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test case for HttpCient
- * The fllowing argument is requred to run this test case:
+ * The fllowing argument is required to run this test case:
  * -Xbootclasspath/p:~/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/8.1.12.v20180117/alpn-boot-8.1.12.v20180117.jar
  *
  * @author Hiroaki Takeuchi - takke30 at gmail.com


### PR DESCRIPTION
This pull request fixes the minor typos detected by https://github.com/client9/misspell.

## before

```
$ misspell .
powered-by-badge/readme.txt:1:13: "aplication" is a misspelling of "application"
twitter4j-async/src/test/java/twitter4j/AsyncTwitterTest.java:144:25: "destorying" is a misspelling of "destroying"
twitter4j-core/src/main/java/twitter4j/TwitterResponse.java:20:97: "avaialble" is a misspelling of "available"
twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java:41:191: "filterd" is a misspelling of "filtered"
twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java:55:191: "filterd" is a misspelling of "filtered"
twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java:69:191: "filterd" is a misspelling of "filtered"
twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java:86:195: "filterd" is a misspelling of "filtered"
twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java:100:195: "filterd" is a misspelling of "filtered"
twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java:116:191: "filterd" is a misspelling of "filtered"
twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java:130:191: "filterd" is a misspelling of "filtered"
twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java:144:191: "filterd" is a misspelling of "filtered"
twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java:161:195: "filterd" is a misspelling of "filtered"
twitter4j-core/src/main/java/twitter4j/api/FriendsFollowersResources.java:175:195: "filterd" is a misspelling of "filtered"
twitter4j-core/src/main/java/twitter4j/conf/ConfigurationFactory.java:34:19: "configuratoin" is a misspelling of "configurations"
twitter4j-core/src/main/java/twitter4j/api/UsersResources.java:133:162: "hexidecimal" is a misspelling of "hexadecimal"
twitter4j-http2-support/src/test/java/twitter4j/Http2ClientTest.java:31:28: "requred" is a misspelling of "required"
```

## after

```
$ misspell .
```