### PR TITLE
add gradle support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,65 @@
+ext {
+    groupId = 'org.twitter4j'
+    versionName = '4.0.7'
+}
+
+allprojects  {
+    apply plugin: 'maven'
+
+    group = groupId
+    version = versionName
+}
+
+// for build
+// $ ./gradlew clean build -x test
+subprojects {
+    apply plugin: 'java'
+
+    sourceCompatibility = 1.6
+    targetCompatibility = 1.6
+
+    [compileJava, compileTestJava, javadoc].each {
+        it.options.encoding = 'UTF-8'
+    }
+
+    repositories {
+        mavenLocal()
+        maven { url "http://repo.maven.apache.org/maven2" }
+    }
+}
+
+// for publish
+// $ ./gradlew publishToMavenLocal  # deploy to ~/.m2/repository/org/twitter4j/
+subprojects {
+    apply plugin: 'maven'
+    apply plugin: 'maven-publish'
+
+    // custom tasks for creating source/javadoc jars
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+    }
+
+    // add javadoc/source jar tasks as artifacts
+    artifacts {
+        archives sourcesJar, javadocJar
+    }
+
+    publishing {
+        publications {
+            MyPublication(MavenPublication) {
+                from components.java
+                artifact sourcesJar
+                artifact javadocJar
+                groupId groupId
+                version versionName
+            }
+        }
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,8 @@
+rootProject.name = 'twitter4j'
+include ':twitter4j-core'
+include ':twitter4j-async'
+include ':twitter4j-stream'
+include ':twitter4j-http2-support'
+include ':twitter4j-appengine'
+include ':twitter4j-examples'
+include ':twitter4j-media-support'

--- a/twitter4j-appengine/build.gradle
+++ b/twitter4j-appengine/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':twitter4j-core')
+    implementation 'com.google.appengine:appengine-api-1.0-sdk:1.8.7'
+    testImplementation 'com.google.appengine:appengine-testing:1.8.7'
+    testImplementation 'com.google.appengine:appengine-api-stubs:1.8.7'
+    testImplementation 'junit:junit:4.10'
+}

--- a/twitter4j-async/build.gradle
+++ b/twitter4j-async/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation project(':twitter4j-core')
+    testImplementation 'junit:junit:4.10'
+}

--- a/twitter4j-core/build.gradle
+++ b/twitter4j-core/build.gradle
@@ -1,0 +1,23 @@
+sourceSets {
+    main {
+        java {
+            srcDirs = [
+                'src/main/java',
+                'src/internal-async/java',
+                'src/internal-http/java',
+                'src/internal-json/java',
+                'src/internal-logging/java',
+                'src/internal-util/java',
+                'src/jmx/java',
+            ]
+        }
+    }
+}
+
+dependencies {
+    compileOnly 'org.slf4j:slf4j-api:1.7.12'
+    compileOnly 'commons-logging:commons-logging-api:1.1'
+    compileOnly 'log4j:log4j:1.2.17'
+    testImplementation 'junit:junit:4.10'
+    testImplementation 'com.googlecode:kryo:1.04'
+}

--- a/twitter4j-examples/build.gradle
+++ b/twitter4j-examples/build.gradle
@@ -1,0 +1,11 @@
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+dependencies {
+    implementation project(':twitter4j-core')
+    implementation project(':twitter4j-async')
+    implementation project(':twitter4j-stream')
+    implementation project(':twitter4j-media-support')
+
+    testImplementation 'junit:junit:4.10'
+}

--- a/twitter4j-http2-support/build.gradle
+++ b/twitter4j-http2-support/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    implementation project(':twitter4j-core')
+    implementation 'com.squareup.okhttp3:okhttp:3.0.1'
+
+    testImplementation 'junit:junit:4.10'
+    // this is just to install alpn-boot jar to local .m2 repository. to be used by maven-surefire-plugin and included in the bootclasspath
+    testImplementation 'org.mortbay.jetty.alpn:alpn-boot:8.1.7.v20160121'
+}

--- a/twitter4j-media-support/build.gradle
+++ b/twitter4j-media-support/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation project(':twitter4j-core')
+
+    testImplementation 'junit:junit:4.10'
+}

--- a/twitter4j-stream/build.gradle
+++ b/twitter4j-stream/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation project(':twitter4j-core')
+    implementation project(':twitter4j-async')
+    testImplementation 'junit:junit:4.10'
+    testImplementation 'org.springframework:spring:2.5.6'
+}


### PR DESCRIPTION
Android developers cannot develop Twitter4J on familiar ground because Android Studio removed maven support.

These only 7 files provides gradle support, so we can develop it with below commands:

```bash
$ ./gradlew clean build -x test
$ ./gradlew publishToMavenLocal  # deploy to ~/.m2/repository/org/twitter4j/
```

----

maven と gradle の2重管理になると思うのでメンテが面倒になるでしょうし、絶対に欲しいというわけではないです。
マージされなくても手動でこれらのファイルを配置してから Android Studio で開発しますので。。