### PR TITLE
More flexible video uploading

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,7 @@ Pierre Lanvin <pierre.lanvin@gmail.com> @planvin
 Pieter Meiresone @_MPieter
 Perry Sakkaris <psakkaris at gmail.com>
 Rajesh Koilpillai <rajesh.koilpillai at gmail.com> @rajeshkp
+Régis Jean-Gilles
 Roberto Estrada <robestradac at gmail.com>
 Robson Cassol <robsoncassol at gmail.com> @robsoncassol
 Roy Reshef <royreshef at gmail.com> @tsipo

--- a/twitter4j-core/src/main/java/twitter4j/ChunkedUploadDelegate.java
+++ b/twitter4j-core/src/main/java/twitter4j/ChunkedUploadDelegate.java
@@ -1,0 +1,166 @@
+package twitter4j;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+
+import twitter4j.conf.ChunkedUploadConfiguration;
+
+/**
+ * Delegate class for chunked uploading
+ *
+ * @author Hiroaki Takeuchi - takke30 at gmail.com
+ * @since Twitter4J 4.0.7
+ */
+/*package*/ class ChunkedUploadDelegate {
+
+    private final static int MAX_VIDEO_SIZE = 512 * 1024 * 1024; // 512MB is a constraint imposed by Twitter for video files
+
+    private final TwitterImpl twitter;
+
+    private ChunkedUploadConfiguration uploadConfiguration;
+
+    /*package*/ ChunkedUploadDelegate(TwitterImpl twitter) {
+        this.twitter = twitter;
+    }
+
+    /*package*/ UploadedMedia uploadMediaChunked(ChunkedUploadConfiguration uploadConfiguration) throws TwitterException {
+        File mediaFile = uploadConfiguration.getFile();
+        this.uploadConfiguration = uploadConfiguration;
+        if (mediaFile != null) {
+            twitter.checkFileValidity(mediaFile);
+            try {
+                return upload(
+                        uploadConfiguration.getMediaType(), uploadConfiguration.getMediaCategory(),
+                        mediaFile.getName(), new FileInputStream(mediaFile), mediaFile.length());
+            } catch (IOException e) {
+                throw new TwitterException(e);
+            }
+        } else {
+            return upload(uploadConfiguration.getMediaType(), uploadConfiguration.getMediaCategory(),
+                    uploadConfiguration.getFilename(), uploadConfiguration.getStream(), uploadConfiguration.getLength());
+        }
+
+    }
+
+    private UploadedMedia upload(String mediaType, String mediaCategory, String fileName, InputStream stream, long mediaLength) throws TwitterException {
+        if (mediaLength > MAX_VIDEO_SIZE) {
+            throw new TwitterException(String.format(Locale.US,
+                    "video file can't be longer than: %d MBytes",
+                    MAX_VIDEO_SIZE / (1024 * 1024)));
+        }
+        try {
+            onProgress("Initializing", 0, mediaLength, "", 0);
+            UploadedMedia uploadedMedia = sendInit(mediaType, mediaCategory, mediaLength);
+            onProgress("Initialized", 0, mediaLength, "", 0);
+            BufferedInputStream buffered = new BufferedInputStream(stream);
+
+            byte[] segmentData = new byte[uploadConfiguration.getSegmentSizeBytes()];
+            long totalRead = 0;
+
+            for (int bytesRead, segmentIndex = 0; (bytesRead = buffered.read(segmentData)) > 0; ++segmentIndex) {
+                totalRead += bytesRead;
+                //no need to close ByteArrayInputStream
+                sendAppend(fileName, new ByteArrayInputStream(segmentData, 0, bytesRead), segmentIndex, uploadedMedia.getMediaId());
+                onProgress("Appended", totalRead, mediaLength, "", 0);
+            }
+            return sendAndWaitForFinalize(uploadedMedia.getMediaId(), mediaLength);
+        } catch (IOException e) {
+            throw new TwitterException(e);
+        }
+    }
+
+    private UploadedMedia sendInit(String mediaType, String mediaCategory, long size) throws TwitterException {
+        return new UploadedMedia(
+                twitter.post(twitter.conf.getUploadBaseURL() + "media/upload.json",
+                        new HttpParameter("command", "INIT"),
+                        new HttpParameter("media_type", mediaType),
+                        new HttpParameter("media_category", mediaCategory),
+                        new HttpParameter("total_bytes", size)).asJSONObject());
+    }
+
+    private void sendAppend(String fileName, InputStream segmentData, int segmentIndex, long mediaId) throws TwitterException {
+        twitter.post(twitter.conf.getUploadBaseURL() + "media/upload.json",
+                new HttpParameter("command", "APPEND"),
+                new HttpParameter("media_id", mediaId),
+                new HttpParameter("segment_index", segmentIndex),
+                new HttpParameter("media", fileName, segmentData));
+    }
+
+    private UploadedMedia sendAndWaitForFinalize(long mediaId, long mediaLength) throws TwitterException {
+        int tries = 0;
+        int maxTries = 20;
+        int lastProgressPercent = 0;
+        int currentProgressPercent = 0;
+        int totalWaitSec = 0;
+        UploadedMedia uploadedMedia = sendFinalize(mediaId);
+        while (tries < maxTries) {
+            if (lastProgressPercent == currentProgressPercent) {
+                tries++;
+            }
+            lastProgressPercent = currentProgressPercent;
+
+            String state = uploadedMedia.getProcessingState();
+            if (state.equals("failed")) {
+                if (uploadedMedia.getProcessingErrorMessage() != null) {
+                    throw new TwitterException(
+                            uploadedMedia.getProcessingErrorMessage() + " (" + uploadedMedia.getProcessingErrorName() + ")",
+                            uploadedMedia.getProcessingErrorCode());
+                } else {
+                    throw new TwitterException("Failed to finalize the chunked upload.");
+                }
+            }
+            if (state.equals("pending") || state.equals("in_progress")) {
+                currentProgressPercent = uploadedMedia.getProgressPercent();
+                int waitSec = uploadedMedia.getProcessingCheckAfterSecs();
+                if (waitSec <= 0) {
+                    throw new TwitterException("Failed to finalize the chunked upload, invalid check_after_secs value " + waitSec);
+                }
+                totalWaitSec += waitSec;
+                if (totalWaitSec > uploadConfiguration.getFinalizeTimeout()) {
+                    throw new TwitterException("Failed to finalize the chunked upload, timed out after " + totalWaitSec + " seconds");
+                }
+
+                onProgress("Finalizing... wait for:" + waitSec + " sec", mediaLength, mediaLength,
+                        state, currentProgressPercent < 0 ? 0 : currentProgressPercent);
+
+                try {
+                    Thread.sleep(waitSec * 1000);
+                } catch (InterruptedException e) {
+                    throw new TwitterException("Failed to finalize the chunked upload.", e);
+                }
+            }
+            if (state.equals("succeeded")) {
+                onProgress("Finalized", mediaLength, mediaLength, state, uploadedMedia.getProgressPercent());
+                return uploadedMedia;
+            }
+            uploadedMedia = getStatus(mediaId);
+        }
+        throw new TwitterException("Failed to finalize the chunked upload, progress has stopped, tried " + tries+1 + " times.");
+    }
+
+    private UploadedMedia sendFinalize(long mediaId) throws TwitterException {
+        return new UploadedMedia(
+                twitter.post(twitter.conf.getUploadBaseURL() + "media/upload.json",
+                            new HttpParameter("command", "FINALIZE"),
+                            new HttpParameter("media_id", mediaId)).asJSONObject());
+    }
+
+    private UploadedMedia getStatus(long mediaId) throws TwitterException {
+        return new UploadedMedia(
+                twitter.get(twitter.conf.getUploadBaseURL() + "media/upload.json",
+                        new HttpParameter("command", "STATUS"),
+                        new HttpParameter("media_id", mediaId)).asJSONObject());
+    }
+
+    private void onProgress(String progress, long uploadedBytes, long totalBytes, String finalizeProcessingState, int finalizeProgressPercent) {
+        if (uploadConfiguration.getCallback() != null) {
+            uploadConfiguration.getCallback().onProgress(progress, uploadedBytes, totalBytes, finalizeProcessingState, finalizeProgressPercent);
+        }
+    }
+
+}

--- a/twitter4j-core/src/main/java/twitter4j/TwitterException.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterException.java
@@ -62,6 +62,12 @@ public class TwitterException extends Exception implements TwitterResponse, Http
         this.statusCode = statusCode;
     }
 
+    public TwitterException(String message, int errorCode) {
+        this(message);
+        this.errorMessage = message;
+        this.errorCode = errorCode;
+    }
+
     @Override
     public String getMessage() {
         StringBuilder value = new StringBuilder();

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -20,13 +20,13 @@ package twitter4j;
 import twitter4j.api.*;
 import twitter4j.auth.Authorization;
 import twitter4j.conf.Configuration;
+import twitter4j.conf.ChunkedUploadConfiguration;
 
 import java.io.*;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -41,20 +41,10 @@ import static twitter4j.HttpParameter.getParameterArray;
  */
 class TwitterImpl extends TwitterBaseImpl implements Twitter {
     private static final long serialVersionUID = 9170943084096085770L;
-    private static final Logger logger = Logger.getLogger(TwitterBaseImpl.class);
-    
+
     private final String IMPLICIT_PARAMS_STR;
     private final HttpParameter[] IMPLICIT_PARAMS;
     private final HttpParameter INCLUDE_MY_RETWEET;
-    
-    private final String CHUNKED_INIT = "INIT";
-    private final String CHUNKED_APPEND = "APPEND";
-    private final String CHUNKED_FINALIZE = "FINALIZE";
-    private final String CHUNKED_STATUS = "STATUS";
-    
-	private final int MB = 1024 * 1024; // 1 MByte
-	private final int MAX_VIDEO_SIZE = 512 * MB; // 512MB is a constraint  imposed by Twitter for video files
-	private final int CHUNK_SIZE = 2 * MB; // max chunk size
 
     private static final ConcurrentHashMap<Configuration, HttpParameter[]> implicitParamsMap = new ConcurrentHashMap<Configuration, HttpParameter[]>();
     private static final ConcurrentHashMap<Configuration, String> implicitParamsStrMap = new ConcurrentHashMap<Configuration, String>();
@@ -274,134 +264,12 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
                 , new HttpParameter("media", fileName, image)).asJSONObject());
     }
 
-	@Override
-	public UploadedMedia uploadMediaChunked(String fileName, InputStream media) throws TwitterException {
-		//If the InputStream is remote, this is will download it into memory speeding up the chunked upload process 
-		byte[] dataBytes = null;
-		try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream(256 * 1024);
-            byte[] buffer = new byte[32768];
-            int n;
-            while((n = media.read(buffer)) != -1) {
-                baos.write(buffer, 0, n);
-            }
-            dataBytes = baos.toByteArray();
-            if (dataBytes.length > MAX_VIDEO_SIZE) {
-				throw new TwitterException(String.format(Locale.US,
-						"video file can't be longer than: %d MBytes",
-						MAX_VIDEO_SIZE / MB));
-			}
-		} catch (IOException ioe) {
-			throw new TwitterException("Failed to download the file.", ioe);
-		}
-		
-		try {
+    @Override
+    public UploadedMedia uploadMediaChunked(ChunkedUploadConfiguration uploadConfiguration) throws TwitterException {
 
-			UploadedMedia uploadedMedia = uploadMediaChunkedInit(dataBytes.length);
-			//no need to close ByteArrayInputStream
-			ByteArrayInputStream dataInputStream = new ByteArrayInputStream(dataBytes);
-			
-			byte[] segmentData = new byte[CHUNK_SIZE];
-			int segmentIndex = 0;
-			int totalRead = 0;
-			int bytesRead = 0;
-			
-			while ((bytesRead = dataInputStream.read(segmentData)) > 0) {
-				totalRead = totalRead + bytesRead;
-				logger.debug("Chunked appened, segment index:" + segmentIndex + " bytes:" + totalRead + "/" + dataBytes.length );
-				//no need to close ByteArrayInputStream
-				ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(segmentData, 0 ,bytesRead);
-				uploadMediaChunkedAppend(fileName, byteArrayInputStream, segmentIndex, uploadedMedia.getMediaId());
-				segmentData = new byte[CHUNK_SIZE];
-				segmentIndex++;
-			}
-			return uploadMediaChunkedFinalize(uploadedMedia.getMediaId());
-		} catch (Exception e) {
-			 throw new TwitterException(e);
-		}
-	}
-    
-	// twurl -H upload.twitter.com "/1.1/media/upload.json" -d
-	// "command=INIT&media_type=video/mp4&total_bytes=4430752"
-    
-    private UploadedMedia uploadMediaChunkedInit(long size) throws TwitterException {
-		return new UploadedMedia(post(
-				conf.getUploadBaseURL() + "media/upload.json",
-				new HttpParameter[] { new HttpParameter("command", CHUNKED_INIT),
-						new HttpParameter("media_type", "video/mp4"), 
-						new HttpParameter("media_category", "tweet_video"),
-						new HttpParameter("total_bytes", size) })
-				.asJSONObject());
-	}
+        return new ChunkedUploadDelegate(this).uploadMediaChunked(uploadConfiguration);
+    }
 
-	// twurl -H upload.twitter.com "/1.1/media/upload.json" -d
-	// "command=APPEND&media_id=601413451156586496&segment_index=0" --file
-	// /path/to/video.mp4 --file-field "media"
-
-    private void uploadMediaChunkedAppend(String fileName, InputStream media, int segmentIndex, long mediaId) throws TwitterException {
-		post(conf.getUploadBaseURL() + "media/upload.json", new HttpParameter[] {
-				new HttpParameter("command", CHUNKED_APPEND), new HttpParameter("media_id", mediaId),
-				new HttpParameter("segment_index", segmentIndex), new HttpParameter("media", fileName, media) });
-	}
-
-	// twurl -H upload.twitter.com "/1.1/media/upload.json" -d
-	// "command=FINALIZE&media_id=601413451156586496"
-
-	private UploadedMedia uploadMediaChunkedFinalize(long mediaId) throws TwitterException {
-		int tries = 0;
-		int maxTries = 20;
-		int lastProgressPercent = 0;
-		int currentProgressPercent = 0;
-		UploadedMedia uploadedMedia = uploadMediaChunkedFinalize0(mediaId);
-		while (tries < maxTries) {
-			if(lastProgressPercent == currentProgressPercent) {
-				tries++;
-			}
-			lastProgressPercent = currentProgressPercent;
-			String state = uploadedMedia.getProcessingState();
-			if (state.equals("failed")) {
-				throw new TwitterException("Failed to finalize the chuncked upload.");
-			}
-			if (state.equals("pending") || state.equals("in_progress")) {
-				currentProgressPercent = uploadedMedia.getProgressPercent();
-				int waitSec = Math.max(uploadedMedia.getProcessingCheckAfterSecs(), 1);
-				logger.debug("Chunked finalize, wait for:" + waitSec + " sec");
-				try {
-					Thread.sleep(waitSec * 1000);
-				} catch (InterruptedException e) {
-					throw new TwitterException("Failed to finalize the chuncked upload.", e);
-				}
-			}
-			if (state.equals("succeeded")) {
-				return uploadedMedia;
-			}
-			uploadedMedia = uploadMediaChunkedStatus(mediaId);
-		} 
-		throw new TwitterException("Failed to finalize the chuncked upload, progress has stopped, tried " + tries+1 + " times.");
-	}
-	
-	private UploadedMedia uploadMediaChunkedFinalize0(long mediaId) throws TwitterException {
-		JSONObject json = post(
-				conf.getUploadBaseURL() + "media/upload.json",
-				new HttpParameter[] {
-						new HttpParameter("command", CHUNKED_FINALIZE),
-						new HttpParameter("media_id", mediaId) })
-				.asJSONObject();
-		logger.debug("Finalize response:" + json);
-		return new UploadedMedia(json);
-	}
-	
-	private UploadedMedia uploadMediaChunkedStatus(long mediaId) throws TwitterException {
-		JSONObject json = get(
-				conf.getUploadBaseURL() + "media/upload.json",
-				new HttpParameter[] {
-						new HttpParameter("command", CHUNKED_STATUS),
-						new HttpParameter("media_id", mediaId) })
-				.asJSONObject();
-		logger.debug("Status response:" + json);
-		return new UploadedMedia(json);
-	}
-    
     /* Search Resources */
 
     @Override
@@ -838,7 +706,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
      * @throws TwitterException when the specified file is not found (FileNotFoundException will be nested)
      *                          , or when the specified file object is not representing a file(IOException will be nested).
      */
-    private void checkFileValidity(File image) throws TwitterException {
+    /*package*/ void checkFileValidity(File image) throws TwitterException {
         if (!image.exists()) {
             //noinspection ThrowableInstanceNeverThrown
             throw new TwitterException(new FileNotFoundException(image + " is not found."));
@@ -1930,7 +1798,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
         }
     }
 
-    private HttpResponse get(String url, HttpParameter... params) throws TwitterException {
+    /*package*/ HttpResponse get(String url, HttpParameter... params) throws TwitterException {
         ensureAuthorizationEnabled();
         if (!conf.isMBeanEnabled()) {
             return http.get(url, mergeImplicitParams(params), auth, this);
@@ -1966,7 +1834,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
         }
     }
 
-    private HttpResponse post(String url, HttpParameter... params) throws TwitterException {
+    /*package*/ HttpResponse post(String url, HttpParameter... params) throws TwitterException {
         ensureAuthorizationEnabled();
         if (!conf.isMBeanEnabled()) {
             return http.post(url, mergeImplicitParams(params), auth, this);

--- a/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
@@ -17,6 +17,7 @@
 package twitter4j.api;
 
 import twitter4j.*;
+import twitter4j.conf.ChunkedUploadConfiguration;
 
 import java.io.File;
 import java.io.InputStream;
@@ -171,7 +172,7 @@ public interface TweetsResources {
      * Uploads media image to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}
      * <br>This method calls https://api.twitter.com/1.1/media/upload.json
      *
-     * @param mediaFile the latest status to be updated.
+     * @param mediaFile media file
      * @return upload result
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/post/statuses/update">POST statuses/update | Twitter Developers</a>
@@ -195,12 +196,11 @@ public interface TweetsResources {
     UploadedMedia uploadMedia(String fileName, InputStream media) throws TwitterException;
     
     /**
-     * Uploads media using chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}. 
+     * Uploads media using chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
      * This should be used for videos.
      * <br>This method calls https://api.twitter.com/1.1/media/upload.json
      *
-     * @param fileName media file name
-     * @param media media body as stream
+     * @param chunkedUploadConfiguration Configuration for chunked uploading
      * @return upload result
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/rest/public/uploading-media#chunkedupload">Uploading Media | Twitter Developers</a>
@@ -208,5 +208,5 @@ public interface TweetsResources {
      * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
      * @since Twitter4J 4.0.7
      */
-    UploadedMedia uploadMediaChunked(String fileName, InputStream media) throws TwitterException;
+    UploadedMedia uploadMediaChunked(ChunkedUploadConfiguration chunkedUploadConfiguration) throws TwitterException;
 }

--- a/twitter4j-core/src/main/java/twitter4j/conf/ChunkedUploadConfiguration.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ChunkedUploadConfiguration.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j.conf;
+
+import java.io.File;
+import java.io.InputStream;
+
+import twitter4j.TwitterException;
+
+/**
+ * Specification for {@link twitter4j.api.TweetsResources}.uploadMediaChunked
+ *
+ * @author Hiroaki Takeuchi - takke30 at gmail.com
+ * @since Twitter4J 4.1.0-beta4
+ */
+public final class ChunkedUploadConfiguration {
+
+    private String mediaType = null;
+
+    private String mediaCategory = null;
+
+    private File file = null;
+
+    private String filename = null;
+    private InputStream stream = null;
+    private long length = -1;
+
+    private int finalizeTimeout = 30;           // When doing a chunked upload, bail out after 30 seconds by default
+    private int segmentSizeBytes = 1024 * 1024; // Segment size defaults to 1MB
+
+    private Callback callback = null;
+
+    /**
+     * Stream type, e.g. "video/mp4", "video/gif", "image/jpeg", ...
+     *
+     * @return media type
+     */
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    /**
+     * Stream category, e.g. "tweet_video", "tweet_gif" or "tweet_image"
+     *
+     * @return media category
+     */
+    public String getMediaCategory() {
+        return mediaCategory;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public InputStream getStream() {
+        return stream;
+    }
+
+    public long getLength() {
+        return length;
+    }
+
+    public Callback getCallback() {
+        return callback;
+    }
+
+    /**
+     * Timeout (in seconds) for chunked upload finalization.
+     *
+     * @return Timeout (in seconds) for chunked upload finalization.
+     */
+    public int getFinalizeTimeout() {
+        return finalizeTimeout;
+    }
+
+    /**
+     * Size of segments (in bytes) when performing a chunked upload
+     *
+     * @return Size of segments (in bytes) when performing a chunked upload
+     */
+    public int getSegmentSizeBytes() {
+        return segmentSizeBytes;
+    }
+
+    public final static class Builder {
+
+        private ChunkedUploadConfiguration conf = new ChunkedUploadConfiguration();
+
+        public Builder movie() {
+            conf.mediaType = "video/mp4";
+            conf.mediaCategory = "tweet_video";
+            return this;
+        }
+
+        public Builder gif() {
+            conf.mediaType = "video/gif";
+            conf.mediaCategory = "tweet_gif";
+            return this;
+        }
+
+        public Builder from(File file) {
+            conf.file = file;
+            return this;
+        }
+
+        public Builder from(String filename, InputStream stream, long length) {
+            conf.filename = filename;
+            conf.stream = stream;
+            conf.length = length;
+            return this;
+        }
+
+        public Builder callback(Callback callback) {
+            conf.callback = callback;
+            return this;
+        }
+
+        public Builder finalizeTimeout(int timeout) {
+            conf.finalizeTimeout = timeout;
+            return this;
+        }
+
+        public Builder segmentSizeBytes(int segmentSizeBytes) {
+            conf.segmentSizeBytes = segmentSizeBytes;
+            return this;
+        }
+
+        public ChunkedUploadConfiguration build() throws TwitterException {
+
+            // must specify file or filename/stream/length
+            if (conf.file == null && conf.filename == null) {
+                throw new TwitterException("specify file");
+            }
+            if (conf.file != null && conf.filename != null) {
+                throw new TwitterException("specify file with File or Filename");
+            }
+
+            if (conf.mediaType == null) {
+                throw new TwitterException("specify media type");
+            }
+
+            return conf;
+        }
+    }
+
+    public interface Callback {
+        void onProgress(String progress, long uploadedBytes, long totalBytes, String finalizeProcessingState, int finalizeProgressPercent);
+    }
+}

--- a/twitter4j-core/src/main/java/twitter4j/conf/ChunkedUploadConfiguration.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ChunkedUploadConfiguration.java
@@ -104,7 +104,7 @@ public final class ChunkedUploadConfiguration {
 
         private ChunkedUploadConfiguration conf = new ChunkedUploadConfiguration();
 
-        public Builder movie() {
+        public Builder video() {
             conf.mediaType = "video/mp4";
             conf.mediaCategory = "tweet_video";
             return this;

--- a/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
+++ b/twitter4j-core/src/main/java/twitter4j/conf/ConfigurationBase.java
@@ -989,7 +989,7 @@ class ConfigurationBase implements Configuration, java.io.Serializable {
         }
     }
 
-    // assures equality after deserializedation
+    // assures equality after deserialization
     protected Object readResolve() throws ObjectStreamException {
         return getInstance(this);
     }

--- a/twitter4j-examples/bin/tweets/uploadMovie.cmd
+++ b/twitter4j-examples/bin/tweets/uploadMovie.cmd
@@ -1,0 +1,9 @@
+echo off
+SETLOCAL enabledelayedexpansion
+cd ..
+call setEnv.cmd
+
+echo on
+"%JAVA_HOME%\bin\java" %MEM_ARGS% -classpath "%CLASSPATH%" twitter4j.examples.tweets.UploadMovie %*
+
+ENDLOCAL

--- a/twitter4j-examples/bin/tweets/uploadMovie.sh
+++ b/twitter4j-examples/bin/tweets/uploadMovie.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+cd ..
+. ./setEnv.sh
+
+RUN_CMD="$JAVA_HOME/bin/java $MEM_ARGS -cp $CLASSPATH twitter4j.examples.tweets.UploadMovie"
+echo $RUN_CMD ${1+"$@"}
+exec $RUN_CMD ${1+"$@"}

--- a/twitter4j-examples/src/main/java/twitter4j/examples/tweets/UploadMovie.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/tweets/UploadMovie.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j.examples.tweets;
+
+import java.io.File;
+
+import twitter4j.Status;
+import twitter4j.StatusUpdate;
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+import twitter4j.UploadedMedia;
+import twitter4j.conf.ChunkedUploadConfiguration;
+
+/**
+ * Example application that uploads movie file.<br>
+ *
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ */
+public final class UploadMovie {
+    /**
+     * Usage: java twitter4j.examples.tweets.UploadMovie [text] [movie-file]
+     *
+     * @param args message
+     */
+    public static void main(String[] args) {
+        if (args.length != 2) {
+            System.out.println("Usage: java twitter4j.examples.tweets.UploadMovie [text] [movie-file]");
+            System.exit(-1);
+        }
+        try {
+            Twitter twitter = new TwitterFactory().getInstance();
+            
+            String movieFileName = args[1];
+            System.out.println("Uploading... [" + movieFileName + "]");
+
+            UploadedMedia media = twitter.uploadMediaChunked(
+                    new ChunkedUploadConfiguration.Builder()
+                            .movie()
+                            .from(new File(movieFileName))
+//                            .segmentSizeBytes(512*1024)
+//                            .finalizeTimeout(120)
+                            .callback((progress, uploadedBytes, totalBytes, finalizeProcessingState, finalizeProgressPercent) ->
+                                    System.out.println(" progress: [" + progress + "], " +
+                                            "uploaded[" + uploadedBytes + "/" + totalBytes + "bytes], " +
+                                            "finalize[" + finalizeProcessingState + "][" + finalizeProgressPercent + "%]"))
+                            .build());
+            System.out.println("Uploaded: id=" + media.getMediaId()
+                    + ", type=" + media.getVideoType() + ", size=" + media.getSize());
+
+            StatusUpdate update = new StatusUpdate(args[0]);
+            update.setMediaIds(media.getMediaId());
+            Status status = twitter.updateStatus(update);
+            System.out.println("Successfully updated the status to [" + status.getText() + "][" + status.getId() + "].");
+            System.exit(0);
+        } catch (TwitterException te) {
+            te.printStackTrace();
+            System.out.println("Failed to update status: " + te.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/twitter4j-examples/src/main/java/twitter4j/examples/tweets/UploadMovie.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/tweets/UploadMovie.java
@@ -50,7 +50,7 @@ public final class UploadMovie {
 
             UploadedMedia media = twitter.uploadMediaChunked(
                     new ChunkedUploadConfiguration.Builder()
-                            .movie()
+                            .video()
                             .from(new File(movieFileName))
 //                            .segmentSizeBytes(512*1024)
 //                            .finalizeTimeout(120)


### PR DESCRIPTION
This PR is based on #255 by dk8996 and #258 by rjean-gilles

Added some features:

- Builder pattern configuration for chunked uploading
```
UploadedMedia media = twitter.uploadMediaChunked(
        new ChunkedUploadConfiguration.Builder()
                .video()
                .from(new File(movieFileName))
                .build());

StatusUpdate update = new StatusUpdate(text);
update.setMediaIds(media.getMediaId());
twitter.updateStatus(update);
```
- Add GIF(animation) uploading feature
```
UploadedMedia media = twitter.uploadMediaChunked(
        new ChunkedUploadConfiguration.Builder()
                .gif()
                .from(new File(movieFileName))
                .build());
...
```
- Add callback for monitoring the progress of uploading
- Add video uploading example

- Moved properties (from #258) to builder-pattern configuration from Configuration
