### PR TITLE
Support creating ext alt text

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -397,7 +397,19 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
 		logger.debug("Status response:" + json);
 		return new UploadedMedia(json);
 	}
-    
+
+    @Override
+    public int createMediaMetadata(long mediaId, String altText) throws TwitterException {
+        try {
+            JSONObject json = new JSONObject()
+                    .put("media_id", ""+mediaId)
+                    .put("alt_text", new JSONObject().put("text", altText));
+            return post(conf.getUploadBaseURL() + "media/metadata/create.json", json).getStatusCode();
+        } catch (JSONException e) {
+            throw new TwitterException(e);
+        }
+    }
+
     /* Search Resources */
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
@@ -209,4 +209,16 @@ public interface TweetsResources {
      * @since Twitter4J 4.0.7
      */
     UploadedMedia uploadMediaChunked(String fileName, InputStream media) throws TwitterException;
+
+    /**
+     * Creates metadata to the uploaded media image
+     * <br>This method calls https://api.twitter.com/1.1/media/metadata/create.json
+     *
+     * @param mediaId media id
+     * @param altText alt text
+     * @return 200 (success), 4xx (Bad Request), 5xx (server error)
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @since Twitter4J 4.0.x
+     */
+    int createMediaMetadata(long mediaId, String altText) throws TwitterException;
 }

--- a/twitter4j-examples/bin/tweets/uploadMultipleImages.cmd
+++ b/twitter4j-examples/bin/tweets/uploadMultipleImages.cmd
@@ -1,0 +1,9 @@
+echo off
+SETLOCAL enabledelayedexpansion
+cd ..
+call setEnv.cmd
+
+echo on
+"%JAVA_HOME%\bin\java" %MEM_ARGS% -classpath "%CLASSPATH%" twitter4j.examples.tweets.UploadMultipleImages %*
+
+ENDLOCAL

--- a/twitter4j-examples/bin/tweets/uploadMultipleImages.sh
+++ b/twitter4j-examples/bin/tweets/uploadMultipleImages.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+cd ..
+. ./setEnv.sh
+
+RUN_CMD="$JAVA_HOME/bin/java $MEM_ARGS -cp $CLASSPATH twitter4j.examples.tweets.UploadMultipleImages"
+echo $RUN_CMD ${1+"$@"}
+exec $RUN_CMD ${1+"$@"}

--- a/twitter4j-examples/src/main/java/twitter4j/examples/tweets/UploadMultipleImages.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/tweets/UploadMultipleImages.java
@@ -52,6 +52,9 @@ public final class UploadMultipleImages {
                         + ", w=" + media.getImageWidth() + ", h=" + media.getImageHeight()
                         + ", type=" + media.getImageType() + ", size=" + media.getSize());
                 mediaIds[i-1] = media.getMediaId();
+
+                // set ext-alt-text
+                twitter.createMediaMetadata(media.getMediaId(), "alt metadata text " + i);
             }
             
             StatusUpdate update = new StatusUpdate(args[0]);


### PR DESCRIPTION
Refreshed version of PR #237 using `post` method from PR #260

----

see https://blog.twitter.com/2016/alt-text-support-for-twitter-cards-and-the-rest-api

we can set the alt text of the attached image as below:

``` java
final UploadedMedia m = twitter.uploadMedia(file);
twitter.createMediaMetadata(m.getMediaId(), "alt metadata text");

final StatusUpdate update = new StatusUpdate(statusText);
final long[] mediaIds = new long[1];
mediaIds[0] = m.getMediaId();
update.setMediaIds(mediaIds);
twitter.updateStatus(update);
```

----

and also added uploadMultipleImages.cmd and uploadMultipleImages.sh, it missed when I added UploadMultipleImages.java